### PR TITLE
solana: fetch `preparedOrderResponse` if undefined

### DIFF
--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -958,7 +958,7 @@ export class MatchingEngineProgram {
     }) {
         const {
             payer,
-            preparedOrderResponse,
+            preparedOrderResponse: inputPreparedOrderResponse,
             auction,
             fastVaa,
             executorToken,
@@ -969,6 +969,10 @@ export class MatchingEngineProgram {
 
         const mint = this.mint;
         const auctionAddress = auction ?? this.auctionAddress(fastVaaAccount.digest());
+
+        const preparedOrderResponse =
+            inputPreparedOrderResponse ??
+            this.preparedOrderResponseAddress(payer, fastVaaAccount.digest());
 
         const { auctionConfig, bestOfferToken } = await (async () => {
             if (inputAuctionConfig === undefined || inputBestOfferToken === undefined) {
@@ -1062,7 +1066,7 @@ export class MatchingEngineProgram {
             payer,
             auction: inputAuction,
             executorToken,
-            preparedOrderResponse,
+            preparedOrderResponse: inputPreparedOrderResponse,
             fastVaa,
             fastVaaAccount,
             auctionConfig: inputAuctionConfig,
@@ -1072,6 +1076,10 @@ export class MatchingEngineProgram {
         const auctionAddress = inputAuction ?? this.auctionAddress(fastVaaAccount.digest());
 
         const mint = this.mint;
+
+        const preparedOrderResponse =
+            inputPreparedOrderResponse ??
+            this.preparedOrderResponseAddress(payer, fastVaaAccount.digest());
 
         const { auctionConfig, bestOfferToken } = await (async () => {
             if (inputAuctionConfig === undefined || inputBestOfferToken === undefined) {
@@ -1177,10 +1185,20 @@ export class MatchingEngineProgram {
         auction?: PublicKey;
         fastVaa: PublicKey;
     }) {
-        const { payer, preparedOrderResponse, auction, fastVaa } = accounts;
+        const {
+            payer,
+            preparedOrderResponse: inputPreparedOrderResponse,
+            auction,
+            fastVaa,
+        } = accounts;
         const fastVaaAccount = await VaaAccount.fetch(this.program.provider.connection, fastVaa);
 
         const mint = this.mint;
+
+        const preparedOrderResponse =
+            inputPreparedOrderResponse ??
+            this.preparedOrderResponseAddress(payer, fastVaaAccount.digest());
+
         const { targetChain, toRouterEndpoint } = await (async () => {
             const message = LiquidityLayerMessage.decode(fastVaaAccount.payload());
             if (message.fastMarketOrder == undefined) {

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -3100,7 +3100,7 @@ describe("Matching Engine", function () {
 
             describe("Active Auction", function () {
                 it("Cannot Settle Executed Auction", async function () {
-                    const { auction, fastVaa, fastVaaAccount, prepareIx, preparedOrderResponse } =
+                    const { auction, fastVaa, fastVaaAccount, prepareIx } =
                         await prepareOrderResponse({
                             executeOrder: true,
                             initAuction: true,
@@ -3128,7 +3128,6 @@ describe("Matching Engine", function () {
                             payer: payer.publicKey,
                             fastVaa,
                             fastVaaAccount,
-                            preparedOrderResponse,
                             executorToken: liquidatorToken,
                             auction,
                             encodedCctpMessage,
@@ -3154,7 +3153,7 @@ describe("Matching Engine", function () {
                 });
 
                 it("Settle", async function () {
-                    const { auction, fastVaa, fastVaaAccount, prepareIx, preparedOrderResponse } =
+                    const { auction, fastVaa, fastVaaAccount, prepareIx } =
                         await prepareOrderResponse({
                             executeOrder: false,
                             initAuction: true,
@@ -3181,7 +3180,6 @@ describe("Matching Engine", function () {
                             payer: payer.publicKey,
                             fastVaa,
                             fastVaaAccount,
-                            preparedOrderResponse,
                             executorToken: liquidatorToken,
                             auction,
                             encodedCctpMessage,

--- a/solana/ts/tests/04__interaction.ts
+++ b/solana/ts/tests/04__interaction.ts
@@ -289,7 +289,7 @@ describe("Matching Engine <> Token Router", function () {
         describe("Settle Auction", function () {
             describe("Settle No Auction (Local)", function () {
                 it("Settle", async function () {
-                    const { prepareIx, preparedOrderResponse, auction, fastVaa, finalizedVaa } =
+                    const { prepareIx, auction, fastVaa, finalizedVaa } =
                         await prepareOrderResponse({
                             initAuction: false,
                             executeOrder: false,
@@ -297,7 +297,6 @@ describe("Matching Engine <> Token Router", function () {
                         });
                     const settleIx = await matchingEngine.settleAuctionNoneLocalIx({
                         payer: payer.publicKey,
-                        preparedOrderResponse,
                         fastVaa,
                         auction,
                     });
@@ -316,12 +315,11 @@ describe("Matching Engine <> Token Router", function () {
 
             describe("Settle Active Auction (Local)", function () {
                 it("Settle", async function () {
-                    const { prepareIx, preparedOrderResponse, auction, fastVaa } =
-                        await prepareOrderResponse({
-                            initAuction: true,
-                            executeOrder: false,
-                            prepareOrderResponse: false,
-                        });
+                    const { prepareIx, auction, fastVaa } = await prepareOrderResponse({
+                        initAuction: true,
+                        executeOrder: false,
+                        prepareOrderResponse: false,
+                    });
 
                     const { address: executorToken } =
                         await splToken.getOrCreateAssociatedTokenAccount(
@@ -333,7 +331,6 @@ describe("Matching Engine <> Token Router", function () {
 
                     const settleIx = await matchingEngine.settleAuctionActiveLocalIx({
                         payer: payer.publicKey,
-                        preparedOrderResponse,
                         fastVaa,
                         auction,
                         executorToken,


### PR DESCRIPTION
## Description
Fixes active auction instructions (and one "none auction" instruction) to fetch `preparedOrderResponse` if it's undefined when passed as a parameter.

## Testing Steps
Adjusted corresponding tests to pass in an undefined `preparedOrderResponse`.