### PR TITLE
solana: add rustdoc comments to modules

### DIFF
--- a/solana/programs/matching-engine/src/lib.rs
+++ b/solana/programs/matching-engine/src/lib.rs
@@ -29,10 +29,13 @@ cfg_if::cfg_if! {
 pub mod matching_engine {
     use super::*;
 
+    /// Complete a fast fill and transfer funds from the mint recipient
+    /// to the token router's custody token account.
     pub fn complete_fast_fill(ctx: Context<CompleteFastFill>) -> Result<()> {
         processor::complete_fast_fill(ctx)
     }
 
+    /// Prepare a slow order response which will subsequently be closed by a settle instruction.
     pub fn prepare_order_response_cctp(
         ctx: Context<PrepareOrderResponseCctp>,
         args: CctpMessageArgs,
@@ -40,22 +43,28 @@ pub mod matching_engine {
         processor::prepare_order_response_cctp(ctx, args)
     }
 
+    /// Settle a completed auction and transfer funds from the mint recipient to the
+    /// token account with the best offer.
     pub fn settle_auction_complete(ctx: Context<SettleAuctionComplete>) -> Result<()> {
         processor::settle_auction_complete(ctx)
     }
 
+    /// Prepare a fill directly.
     pub fn settle_auction_none_cctp(ctx: Context<SettleAuctionNoneCctp>) -> Result<()> {
         processor::settle_auction_none_cctp(ctx)
     }
 
+    /// Prepare a fill directly in which the target network is the same network where the token router resides.
     pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result<()> {
         processor::settle_auction_none_local(ctx)
     }
 
+    /// Settle an active auction and prepares a fill.
     pub fn settle_auction_active_cctp(ctx: Context<SettleAuctionActiveCctp>) -> Result<()> {
         processor::settle_auction_active_cctp(ctx)
     }
 
+    /// Settle an active auction and prepare a fill in which the target network is the same network where the token router resides.
     pub fn settle_auction_active_local(ctx: Context<SettleAuctionActiveLocal>) -> Result<()> {
         processor::settle_auction_active_local(ctx)
     }
@@ -67,6 +76,7 @@ pub mod matching_engine {
         processor::initialize(ctx, auction_params)
     }
 
+    /// Add a token router endpoint for a CCTP-enabled chain.
     pub fn add_cctp_router_endpoint(
         ctx: Context<AddCctpRouterEndpoint>,
         args: AddCctpRouterEndpointArgs,
@@ -74,14 +84,17 @@ pub mod matching_engine {
         processor::add_cctp_router_endpoint(ctx, args)
     }
 
+    /// Add a token router in which the endpoint resides on the same network as that of the matching engine.
     pub fn add_local_router_endpoint(ctx: Context<AddLocalRouterEndpoint>) -> Result<()> {
         processor::add_local_router_endpoint(ctx)
     }
 
+    /// Disable a token router endpoint.
     pub fn disable_router_endpoint(ctx: Context<DisableRouterEndpoint>) -> Result<()> {
         processor::disable_router_endpoint(ctx)
     }
 
+    /// Update a token router endpoint for a CCTP-enabled chain.
     pub fn update_cctp_router_endpoint(
         ctx: Context<UpdateCctpRouterEndpoint>,
         args: AddCctpRouterEndpointArgs,
@@ -89,28 +102,36 @@ pub mod matching_engine {
         processor::update_cctp_router_endpoint(ctx, args)
     }
 
+    /// Update a token router endpoint that resides on the same network as that of the matching engine.
     pub fn update_local_router_endpoint(ctx: Context<UpdateLocalRouterEndpoint>) -> Result<()> {
         processor::update_local_router_endpoint(ctx)
     }
 
+    /// Submit request to transfer ownership of a token router.
+    /// This instruction is owner-only.
     pub fn submit_ownership_transfer_request(
         ctx: Context<SubmitOwnershipTransferRequest>,
     ) -> Result<()> {
         processor::submit_ownership_transfer_request(ctx)
     }
 
+    /// Confirm request to transfer ownership of a token router.
+    /// This instruction requires the `custodian` included in the request to
+    /// be a pending owner set as part of [`submit_ownership_transfer_request`].
     pub fn confirm_ownership_transfer_request(
         ctx: Context<ConfirmOwnershipTransferRequest>,
     ) -> Result<()> {
         processor::confirm_ownership_transfer_request(ctx)
     }
 
+    /// Cancel request to transfer ownership of a token router.
     pub fn cancel_ownership_transfer_request(
         ctx: Context<CancelOwnershipTransferRequest>,
     ) -> Result<()> {
         processor::cancel_ownership_transfer_request(ctx)
     }
 
+    /// Propose an update to auction parameters.
     pub fn propose_auction_parameters(
         ctx: Context<ProposeAuctionParameters>,
         params: AuctionParameters,
@@ -118,34 +139,42 @@ pub mod matching_engine {
         processor::propose_auction_parameters(ctx, params)
     }
 
+    /// Enact an update to auction parameters. This instruction is owner-only.
     pub fn update_auction_parameters(ctx: Context<UpdateAuctionParameters>) -> Result<()> {
         processor::update_auction_parameters(ctx)
     }
 
+    /// Sets an assistant to the owner. This instruction is owner-only.
     pub fn update_owner_assistant(ctx: Context<UpdateOwnerAssistant>) -> Result<()> {
         processor::update_owner_assistant(ctx)
     }
 
+    /// Update the fee recipient.
     pub fn update_fee_recipient(ctx: Context<UpdateFeeRecipient>) -> Result<()> {
         processor::update_fee_recipient(ctx)
     }
 
+    /// Open an auction for the fulfillment of a fast market order and place an initial offer.
     pub fn place_initial_offer(ctx: Context<PlaceInitialOffer>, fee_offer: u64) -> Result<()> {
         processor::place_initial_offer(ctx, fee_offer)
     }
 
+    /// Improve best offer for an auction.
     pub fn improve_offer(ctx: Context<ImproveOffer>, fee_offer: u64) -> Result<()> {
         processor::improve_offer(ctx, fee_offer)
     }
 
+    /// Execute a fast market order.
     pub fn execute_fast_order_cctp(ctx: Context<ExecuteFastOrderCctp>) -> Result<()> {
         processor::execute_fast_order_cctp(ctx)
     }
 
+    /// Execute a fast market order in which the target network is the same network where the token router resides.
     pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<()> {
         processor::execute_fast_order_local(ctx)
     }
 
+    /// Close an open proposal.
     pub fn close_proposal(ctx: Context<CloseProposal>) -> Result<()> {
         processor::close_proposal(ctx)
     }

--- a/solana/programs/matching-engine/src/processor/complete_fast_fill.rs
+++ b/solana/programs/matching-engine/src/processor/complete_fast_fill.rs
@@ -72,7 +72,8 @@ pub struct CompleteFastFill<'info> {
     system_program: Program<'info, System>,
 }
 
-/// TODO: docstring
+/// Completes a fast fill and transfers the desired amount from the mint recipient
+/// to the token router's custody token account.
 pub fn complete_fast_fill(ctx: Context<CompleteFastFill>) -> Result<()> {
     let vaa = VaaAccount::load_unchecked(&ctx.accounts.vaa);
 

--- a/solana/programs/token-router/src/lib.rs
+++ b/solana/programs/token-router/src/lib.rs
@@ -28,6 +28,10 @@ const PREPARED_CUSTODY_TOKEN_SEED_PREFIX: &[u8] = b"prepared-custody";
 pub mod token_router {
     use super::*;
 
+    /// Prepare market order for the transfer of funds.
+    ///
+    /// This instruction will validate arguments before transferring the desired
+    /// amount to the custody token account.
     pub fn prepare_market_order(
         ctx: Context<PrepareMarketOrder>,
         args: PrepareMarketOrderArgs,
@@ -35,22 +39,31 @@ pub mod token_router {
         processor::prepare_market_order(ctx, args)
     }
 
+    /// Close prepared order.
+    ///
+    /// This instruction transfers the funds in the prepared custody token account to
+    /// the refund token account. It then closes the prepared custody token account.
     pub fn close_prepared_order(ctx: Context<ClosePreparedOrder>) -> Result<()> {
         processor::close_prepared_order(ctx)
     }
 
+    /// Place market order through CCTP.
     pub fn place_market_order_cctp(ctx: Context<PlaceMarketOrderCctp>) -> Result<()> {
         processor::place_market_order_cctp(ctx)
     }
 
+    /// Redeem fill by reconciling CCTP messages to mint tokens for the [`mint_recipient`] token account.
     pub fn redeem_cctp_fill(ctx: Context<RedeemCctpFill>, args: CctpMessageArgs) -> Result<()> {
         processor::redeem_cctp_fill(ctx, args)
     }
 
+    /// Redeem fast fill by transferring funds from the payer to the prepared fill token account.
     pub fn redeem_fast_fill(ctx: Context<RedeemFastFill>) -> Result<()> {
         processor::redeem_fast_fill(ctx)
     }
 
+    /// Consume prepared fill by transferring funds from the prepared custody token
+    /// account to the destination token account.
     pub fn consume_prepared_fill(ctx: Context<ConsumePreparedFill>) -> Result<()> {
         processor::consume_prepared_fill(ctx)
     }
@@ -211,6 +224,7 @@ pub mod token_router {
     //     processor::complete_wrapped_transfer_with_relay(ctx, _vaa_hash)
     // }
 
+    /// Authorize upgrade of token router program.
     pub fn authorize_upgrade(ctx: Context<AuthorizeUpgrade>) -> Result<()> {
         processor::authorize_upgrade(ctx)
     }

--- a/solana/programs/token-router/src/processor/close_prepared_order.rs
+++ b/solana/programs/token-router/src/processor/close_prepared_order.rs
@@ -54,7 +54,10 @@ pub struct ClosePreparedOrder<'info> {
     token_program: Program<'info, token::Token>,
 }
 
-/// TODO: add docstring
+/// Close prepared order.
+///
+/// This instruction transfers the funds in the prepared custody token account to
+/// the refund token account. It then closes the prepared custody token account.
 pub fn close_prepared_order(ctx: Context<ClosePreparedOrder>) -> Result<()> {
     token::transfer(
         CpiContext::new_with_signer(

--- a/solana/programs/token-router/src/processor/consume_prepared_fill.rs
+++ b/solana/programs/token-router/src/processor/consume_prepared_fill.rs
@@ -59,7 +59,8 @@ pub struct ConsumePreparedFill<'info> {
     token_program: Program<'info, token::Token>,
 }
 
-/// TODO: add docstring
+/// Consume prepared fill by transferring funds from the prepared custody token
+/// account to the destination token account.
 pub fn consume_prepared_fill(ctx: Context<ConsumePreparedFill>) -> Result<()> {
     token::transfer(
         CpiContext::new_with_signer(

--- a/solana/programs/token-router/src/processor/market_order/prepare.rs
+++ b/solana/programs/token-router/src/processor/market_order/prepare.rs
@@ -93,7 +93,7 @@ pub struct PrepareMarketOrderArgs {
     pub redeemer_message: Vec<u8>,
 }
 
-/// TODO: add docstring
+/// Prepare a market order for the transfer of funds.
 pub fn prepare_market_order(
     ctx: Context<PrepareMarketOrder>,
     args: PrepareMarketOrderArgs,


### PR DESCRIPTION
## Description

Added `rustdoc` comments to the matching engine and token router modules.

## Testing Steps
N/A.