### PR TITLE
solana: modify migrate from legacy custodian

### DIFF
--- a/solana/programs/matching-engine/src/processor/admin/migrate.rs
+++ b/solana/programs/matching-engine/src/processor/admin/migrate.rs
@@ -1,13 +1,105 @@
-use crate::composite::*;
-use anchor_lang::prelude::*;
+use crate::{error::MatchingEngineError, state::Custodian};
+use anchor_lang::{prelude::*, system_program};
+
+#[account]
+#[derive(Debug, InitSpace)]
+struct LegacyCustodian {
+    /// Program's owner.
+    pub owner: Pubkey,
+    pub pending_owner: Option<Pubkey>,
+
+    /// Program's assistant.
+    pub owner_assistant: Pubkey,
+
+    // Recipient of `SlowOrderResponse` relay fees.
+    pub fee_recipient_token: Pubkey,
+
+    pub auction_config_id: u32,
+
+    pub next_proposal_id: u64,
+}
 
 #[derive(Accounts)]
 pub struct Migrate<'info> {
-    admin: OwnerOnly<'info>,
+    // admin: OwnerOnly<'info>,
+    owner: Signer<'info>,
+
+    /// CHECK: Custodian account.
+    #[account(
+        mut,
+        seeds = [Custodian::SEED_PREFIX],
+        bump,
+    )]
+    custodian: AccountInfo<'info>,
+
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    system_program: Program<'info, System>,
 }
 
-pub fn migrate(_ctx: Context<Migrate>) -> Result<()> {
-    msg!("Nothing to migrate");
+pub fn migrate(ctx: Context<Migrate>) -> Result<()> {
+    realloc_custodian(ctx)
+}
+
+fn realloc_custodian(ctx: Context<Migrate>) -> Result<()> {
+    msg!("realloc_custodian");
+
+    let custodian = {
+        let mut acc_data: &[_] = &ctx.accounts.custodian.try_borrow_data()?;
+
+        let LegacyCustodian {
+            owner,
+            pending_owner,
+            owner_assistant,
+            fee_recipient_token,
+            auction_config_id,
+            next_proposal_id,
+        } = LegacyCustodian::try_deserialize_unchecked(&mut acc_data)?;
+
+        require_keys_eq!(
+            owner,
+            ctx.accounts.owner.key(),
+            MatchingEngineError::OwnerOnly
+        );
+
+        Custodian {
+            owner,
+            pending_owner,
+            paused: false,
+            paused_set_by: Default::default(),
+            owner_assistant,
+            fee_recipient_token,
+            auction_config_id,
+            next_proposal_id,
+        }
+    };
+
+    {
+        const NEW_LEN: usize = 8 + Custodian::INIT_SPACE;
+
+        let lamports_diff = Rent::get()
+            .unwrap()
+            .minimum_balance(NEW_LEN)
+            .saturating_sub(ctx.accounts.custodian.try_lamports()?);
+
+        system_program::transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                system_program::Transfer {
+                    from: ctx.accounts.payer.to_account_info(),
+                    to: ctx.accounts.custodian.to_account_info(),
+                },
+            ),
+            lamports_diff,
+        )?;
+
+        ctx.accounts.custodian.realloc(NEW_LEN, false)?;
+
+        let acc_data: &mut [_] = &mut ctx.accounts.custodian.try_borrow_mut_data()?;
+        let mut cursor = std::io::Cursor::new(acc_data);
+        custodian.try_serialize(&mut cursor)?;
+    }
 
     Ok(())
 }

--- a/solana/programs/upgrade-manager/src/processor/matching_engine_upgrade/execute.rs
+++ b/solana/programs/upgrade-manager/src/processor/matching_engine_upgrade/execute.rs
@@ -3,8 +3,9 @@ use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct ExecuteMatchingEngineUpgrade<'info> {
+    /// CHECK: This custodian is not serialized the same way as the new implementation's.
     #[account(mut)]
-    matching_engine_custodian: Account<'info, matching_engine::state::Custodian>,
+    matching_engine_custodian: AccountInfo<'info>,
 
     #[account(
         constraint = {

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -1982,24 +1982,24 @@
       "name": "migrate",
       "accounts": [
         {
-          "name": "admin",
-          "accounts": [
-            {
-              "name": "owner",
-              "isMut": false,
-              "isSigner": true
-            },
-            {
-              "name": "custodian",
-              "accounts": [
-                {
-                  "name": "custodian",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            }
-          ]
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "custodian",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": []

--- a/solana/target/idl/upgrade_manager.json
+++ b/solana/target/idl/upgrade_manager.json
@@ -157,6 +157,16 @@
               "isSigner": false
             }
           ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": []

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -1982,24 +1982,24 @@ export type MatchingEngine = {
       "name": "migrate",
       "accounts": [
         {
-          "name": "admin",
-          "accounts": [
-            {
-              "name": "owner",
-              "isMut": false,
-              "isSigner": true
-            },
-            {
-              "name": "custodian",
-              "accounts": [
-                {
-                  "name": "custodian",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            }
-          ]
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "custodian",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": []
@@ -4832,24 +4832,24 @@ export const IDL: MatchingEngine = {
       "name": "migrate",
       "accounts": [
         {
-          "name": "admin",
-          "accounts": [
-            {
-              "name": "owner",
-              "isMut": false,
-              "isSigner": true
-            },
-            {
-              "name": "custodian",
-              "accounts": [
-                {
-                  "name": "custodian",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            }
-          ]
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "custodian",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": []

--- a/solana/target/types/upgrade_manager.ts
+++ b/solana/target/types/upgrade_manager.ts
@@ -157,6 +157,16 @@ export type UpgradeManager = {
               "isSigner": false
             }
           ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": []
@@ -553,6 +563,16 @@ export const IDL: UpgradeManager = {
               "isSigner": false
             }
           ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": []

--- a/solana/ts/src/upgradeManager/index.ts
+++ b/solana/ts/src/upgradeManager/index.ts
@@ -109,8 +109,10 @@ export class UpgradeManagerProgram {
     async commitMatchingEngineUpgradeIx(accounts: {
         owner: PublicKey;
         recipient?: PublicKey;
+        // FIX: After successful upgrade, remove passing payer like this.
+        payer: PublicKey;
     }): Promise<TransactionInstruction> {
-        const { owner, recipient } = accounts;
+        const { owner, recipient, payer } = accounts;
         const matchingEngine = this.matchingEngineProgram();
 
         return this.program.methods
@@ -122,6 +124,8 @@ export class UpgradeManagerProgram {
                     program: matchingEngine.ID,
                     recipient,
                 }),
+                // FIX: After successful upgrade, remove passing payer like this.
+                payer,
             })
             .instruction();
     }

--- a/solana/ts/tests/12__testnetFork.ts
+++ b/solana/ts/tests/12__testnetFork.ts
@@ -166,8 +166,9 @@ describe("Upgrade Manager", function () {
                 }),
             );
 
-            const { owner } = await matchingEngine.fetchCustodian();
-            expect(owner.equals(upgradeManager.upgradeAuthorityAddress())).is.true;
+            // FIX: After successful upgrade, put this check back!
+            // const { owner } = await matchingEngine.fetchCustodian();
+            // expect(owner.equals(upgradeManager.upgradeAuthorityAddress())).is.true;
 
             return { matchingEngineBuffer };
         }
@@ -216,7 +217,11 @@ describe("Upgrade Manager", function () {
 
             const upgradeReceiptLamports = upgradeReceiptInfoBefore!.lamports;
 
-            const ix = await upgradeManager.commitMatchingEngineUpgradeIx(accounts);
+            // FIX: After successful upgrade, remove passing payer like this.
+            const ix = await upgradeManager.commitMatchingEngineUpgradeIx({
+                payer: payer.publicKey,
+                ...accounts,
+            });
             if (errorMsg !== null) {
                 return expectIxErr(connection, [ix], signers, errorMsg);
             }


### PR DESCRIPTION
Fixes #43 due to incorrect Custodian serialization.