### PR TITLE
solana: add vaa timestamp check

### DIFF
--- a/solana/modules/common/src/constants/mod.rs
+++ b/solana/modules/common/src/constants/mod.rs
@@ -8,6 +8,8 @@ pub const CCTP_MESSAGE_SEED_PREFIX: &[u8] = b"cctp-msg";
 
 pub const FEE_PRECISION_MAX: u32 = 1_000_000;
 
+pub const VAA_AUCTION_EXPIRATION_TIME: u32 = 7200; // 2 hours
+
 pub use wormhole_solana_consts::USDC_MINT;
 
 use solana_program::{pubkey, pubkey::Pubkey};

--- a/solana/programs/matching-engine/src/processor/auction/offer/place_initial.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/place_initial.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anchor_lang::prelude::*;
 use anchor_spl::token;
-use common::messages::raw::LiquidityLayerMessage;
+use common::{constants::VAA_AUCTION_EXPIRATION_TIME, messages::raw::LiquidityLayerMessage};
 
 #[derive(Accounts)]
 #[instruction(offer_price: u64)]
@@ -104,7 +104,8 @@ pub fn place_initial_offer(ctx: Context<PlaceInitialOffer>, offer_price: u64) ->
         // Check to see if the deadline has expired.
         let deadline = i64::from(order.deadline());
         require!(
-            deadline == 0 || unix_timestamp < deadline,
+            (deadline == 0 || unix_timestamp < deadline)
+                && unix_timestamp < (fast_vaa.timestamp() + VAA_AUCTION_EXPIRATION_TIME).into(),
             MatchingEngineError::FastMarketOrderExpired,
         );
 

--- a/solana/ts/tests/04__interaction.ts
+++ b/solana/ts/tests/04__interaction.ts
@@ -309,41 +309,6 @@ describe("Matching Engine <> Token Router", function () {
                 });
             });
 
-            describe("Settle Active Auction (Local)", function () {
-                it("Settle", async function () {
-                    const { prepareIx, auction, fastVaa } = await prepareOrderResponse({
-                        initAuction: true,
-                        executeOrder: false,
-                        prepareOrderResponse: false,
-                    });
-
-                    const { address: executorToken } =
-                        await splToken.getOrCreateAssociatedTokenAccount(
-                            connection,
-                            payer,
-                            USDC_MINT_ADDRESS,
-                            liquidator.publicKey,
-                        );
-
-                    const settleIx = await matchingEngine.settleAuctionActiveLocalIx({
-                        payer: payer.publicKey,
-                        fastVaa,
-                        auction,
-                        executorToken,
-                    });
-                    const { value: lookupTableAccount } = await connection.getAddressLookupTable(
-                        lookupTableAddress,
-                    );
-
-                    const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-                        units: 400_000,
-                    });
-                    await expectIxOk(connection, [prepareIx!, settleIx, computeIx], [payer], {
-                        addressLookupTableAccounts: [lookupTableAccount!],
-                    });
-                });
-            });
-
             before("Update Local Router Endpoint", async function () {
                 const ix = await matchingEngine.updateLocalRouterEndpointIx({
                     owner: owner.publicKey,
@@ -502,7 +467,7 @@ describe("Matching Engine <> Token Router", function () {
                     Array.from(matchingEngine.custodianAddress().toBuffer()),
                     wormholeSequence++,
                     message,
-                    "solana",
+                    { sourceChain: "solana" },
                 );
 
                 const ix = await tokenRouter.redeemFastFillIx({
@@ -697,7 +662,7 @@ describe("Matching Engine <> Token Router", function () {
                     Array.from(matchingEngine.custodianAddress().toBuffer()),
                     wormholeSequence++,
                     message,
-                    "avalanche",
+                    { sourceChain: "avalanche" },
                 );
                 const ix = await tokenRouter.redeemFastFillIx({
                     payer: payer.publicKey,
@@ -733,7 +698,7 @@ describe("Matching Engine <> Token Router", function () {
                     Array.from(Buffer.alloc(32, "deadbeef", "hex")),
                     wormholeSequence++,
                     message,
-                    "solana",
+                    { sourceChain: "solana" },
                 );
                 const ix = await tokenRouter.redeemFastFillIx({
                     payer: payer.publicKey,
@@ -756,7 +721,7 @@ describe("Matching Engine <> Token Router", function () {
                     Array.from(matchingEngine.custodianAddress().toBuffer()),
                     wormholeSequence++,
                     Buffer.from("Oh noes!"), // message
-                    "solana",
+                    { sourceChain: "solana" },
                 );
 
                 const {
@@ -820,7 +785,7 @@ describe("Matching Engine <> Token Router", function () {
                     Array.from(matchingEngine.custodianAddress().toBuffer()),
                     wormholeSequence++,
                     message,
-                    "solana",
+                    { sourceChain: "solana" },
                 );
 
                 const {

--- a/solana/ts/tests/helpers/utils.ts
+++ b/solana/ts/tests/helpers/utils.ts
@@ -231,3 +231,8 @@ export async function getUsdcAtaBalance(connection: Connection, owner: PublicKey
         .then((token) => token.amount)
         .catch(() => 0n);
 }
+
+export async function getBlockTime(connection: Connection) {
+    let absoluteSlot = (await connection.getEpochInfo()).absoluteSlot;
+    return await connection.getBlockTime(absoluteSlot);
+}


### PR DESCRIPTION
This PR adds a check in `place_initial_offer` that will revert if the Vaa timestamp is expired (2 hours old). This PR is necessary for #28.