### PR TITLE
solana: historical auctions

### DIFF
--- a/solana/modules/common/src/constants/mod.rs
+++ b/solana/modules/common/src/constants/mod.rs
@@ -6,10 +6,6 @@ pub const CUSTODY_TOKEN_SEED_PREFIX: &[u8] = b"custody";
 pub const CORE_MESSAGE_SEED_PREFIX: &[u8] = b"core-msg";
 pub const CCTP_MESSAGE_SEED_PREFIX: &[u8] = b"cctp-msg";
 
-pub const FEE_PRECISION_MAX: u32 = 1_000_000;
-
-pub const VAA_AUCTION_EXPIRATION_TIME: u32 = 7200; // 2 hours
-
 pub use wormhole_solana_consts::USDC_MINT;
 
 use solana_program::{pubkey, pubkey::Pubkey};

--- a/solana/programs/matching-engine/src/error.rs
+++ b/solana/programs/matching-engine/src/error.rs
@@ -54,4 +54,9 @@ pub enum MatchingEngineError {
     ExecutorTokenMismatch = 0x414,
     AuctionNotCompleted = 0x41a,
     CarpingNotAllowed = 0x41e,
+    AuctionNotSettled = 0x420,
+
+    CannotCloseAuctionYet = 0x500,
+    AuctionHistoryNotFull = 0x502,
+    AuctionHistoryFull = 0x504,
 }

--- a/solana/programs/matching-engine/src/lib.rs
+++ b/solana/programs/matching-engine/src/lib.rs
@@ -309,4 +309,23 @@ pub mod matching_engine {
     pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result<()> {
         processor::settle_auction_none_local(ctx)
     }
+
+    /// This instruction is used to create the first `AuctionHistory` account, whose PDA is derived
+    /// using ID == 0.
+    /// # Arguments
+    ///
+    /// * `ctx` - `CreateFirstAuctionHistory` context.
+    pub fn create_first_auction_history(ctx: Context<CreateFirstAuctionHistory>) -> Result<()> {
+        processor::create_first_auction_history(ctx)
+    }
+
+    /// This instruction is used to create a new `AuctionHistory` account. The PDA is derived using
+    /// its ID. A new history account can be created only when the current one is full (number of
+    /// entries equals the hard-coded max entries).
+    /// # Arguments
+    ///
+    /// * `ctx` - `CreateNewAuctionHistory` context.
+    pub fn create_new_auction_history(ctx: Context<CreateNewAuctionHistory>) -> Result<()> {
+        processor::create_new_auction_history(ctx)
+    }
 }

--- a/solana/programs/matching-engine/src/lib.rs
+++ b/solana/programs/matching-engine/src/lib.rs
@@ -32,6 +32,9 @@ const LOCAL_CUSTODY_TOKEN_SEED_PREFIX: &[u8] = b"local-custody";
 const PREPARED_CUSTODY_TOKEN_SEED_PREFIX: &[u8] = b"prepared-custody";
 const TRANSFER_AUTHORITY_SEED_PREFIX: &[u8] = b"transfer-authority";
 
+const FEE_PRECISION_MAX: u32 = 1_000_000;
+const VAA_AUCTION_EXPIRATION_TIME: u32 = 2 * 60 * 60; // 2 hours
+
 #[program]
 pub mod matching_engine {
     use super::*;
@@ -327,5 +330,9 @@ pub mod matching_engine {
     /// * `ctx` - `CreateNewAuctionHistory` context.
     pub fn create_new_auction_history(ctx: Context<CreateNewAuctionHistory>) -> Result<()> {
         processor::create_new_auction_history(ctx)
+    }
+
+    pub fn add_auction_history_entry(ctx: Context<AddAuctionHistoryEntry>) -> Result<()> {
+        processor::add_auction_history_entry(ctx)
     }
 }

--- a/solana/programs/matching-engine/src/lib.rs
+++ b/solana/programs/matching-engine/src/lib.rs
@@ -332,6 +332,20 @@ pub mod matching_engine {
         processor::create_new_auction_history(ctx)
     }
 
+    /// This instruction is used to add a new entry to the `AuctionHistory` account if there is an
+    /// `Auction` with some info. Regardless of whether there is info in this account, the
+    /// instruction finishes its operation by closing this auction account. If the history account
+    /// is full, this instruction will revert and `create_new_auction_history`` will have to be
+    /// called to initialize another history account.
+    ///
+    /// This mechanism is important for auction participants. The initial offer participant will
+    /// pay lamports to create the `Auction` account. This instruction allows him to reclaim some
+    /// lamports by closing that account. And the protocol's fee recipient will be able to claim
+    /// lamports by closing the empty `Auction` account it creates when he calls any of the
+    /// `settle_auction_none_*` instructions.
+    /// # Arguments
+    ///
+    /// * `ctx` - `AddAuctionHistoryEntry` context.
     pub fn add_auction_history_entry(ctx: Context<AddAuctionHistoryEntry>) -> Result<()> {
         processor::add_auction_history_entry(ctx)
     }

--- a/solana/programs/matching-engine/src/lib.rs
+++ b/solana/programs/matching-engine/src/lib.rs
@@ -33,7 +33,7 @@ const PREPARED_CUSTODY_TOKEN_SEED_PREFIX: &[u8] = b"prepared-custody";
 const TRANSFER_AUTHORITY_SEED_PREFIX: &[u8] = b"transfer-authority";
 
 const FEE_PRECISION_MAX: u32 = 1_000_000;
-const VAA_AUCTION_EXPIRATION_TIME: u32 = 2 * 60 * 60; // 2 hours
+const VAA_AUCTION_EXPIRATION_TIME: i64 = 2 * 60 * 60; // 2 hours
 
 #[program]
 pub mod matching_engine {

--- a/solana/programs/matching-engine/src/processor/auction/history/add_entry.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/add_entry.rs
@@ -1,0 +1,153 @@
+use crate::{
+    composite::*,
+    error::MatchingEngineError,
+    state::{
+        Auction, AuctionEntry, AuctionHistory, AuctionHistoryInternal, AuctionInfo, AuctionStatus,
+    },
+};
+use anchor_lang::{prelude::*, system_program};
+use anchor_spl::token;
+
+#[derive(Accounts)]
+pub struct AddAuctionHistoryEntry<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    custodian: CheckedCustodian<'info>,
+
+    /// CHECK: Auction history account. This account is not deserialized via Anchor account context
+    /// because we will be writing to this account without using Anchor's [AccountsExit].
+    #[account(
+        mut,
+        constraint = {
+            require_keys_eq!(
+                *history.owner,
+                crate::id(),
+                ErrorCode::ConstraintOwner,
+            );
+
+            let mut acc_data: &[_] = &history.try_borrow_data()?;
+            let history = AuctionHistoryInternal::try_deserialize(&mut acc_data)?;
+
+            require!(
+                history.num_entries < AuctionHistory::MAX_ENTRIES,
+                MatchingEngineError::AuctionHistoryFull,
+            );
+
+            true
+        }
+    )]
+    history: AccountInfo<'info>,
+
+    #[account(
+        mut,
+        close = beneficiary,
+        constraint = {
+            require!(
+                matches!(auction.status, AuctionStatus::Settled {..}),
+                MatchingEngineError::AuctionNotSettled,
+            );
+
+            require!(
+                Clock::get().unwrap().unix_timestamp
+                    >= i64::from(auction.vaa_timestamp + crate::VAA_AUCTION_EXPIRATION_TIME),
+                MatchingEngineError::CannotCloseAuctionYet,
+            );
+
+            true
+        }
+    )]
+    auction: Account<'info, Auction>,
+
+    /// CHECK: This account will either be the owner of the fee recipient token account (if there
+    /// was no auction) or the owner of the initial offer token account.
+    #[account(mut)]
+    beneficiary: AccountInfo<'info>,
+
+    #[account(
+        token::authority = beneficiary,
+        address = {
+            match &auction.info {
+                Some(info) => info.initial_offer_token,
+                None => custodian.fee_recipient_token,
+            }
+        }
+    )]
+    beneficiary_token: Account<'info, token::TokenAccount>,
+
+    system_program: Program<'info, system_program::System>,
+}
+
+pub fn add_auction_history_entry(ctx: Context<AddAuctionHistoryEntry>) -> Result<()> {
+    match ctx.accounts.auction.info {
+        Some(info) => handle_add_auction_history_entry(ctx, info),
+        None => Ok(()),
+    }
+}
+
+fn handle_add_auction_history_entry(
+    ctx: Context<AddAuctionHistoryEntry>,
+    info: AuctionInfo,
+) -> Result<()> {
+    let mut history = {
+        let mut acc_data: &[_] = &ctx.accounts.history.data.borrow();
+        AuctionHistoryInternal::try_deserialize_unchecked(&mut acc_data).unwrap()
+    };
+
+    // This is safe because we already checked that this is less than MAX_ENTRIES.
+    history.num_entries += 1;
+
+    // Update the history account with this new entry's vaa timestamp if it is less than the min or
+    // greater than the max.
+    let auction = &ctx.accounts.auction;
+    if auction.vaa_timestamp < history.min_timestamp {
+        history.min_timestamp = auction.vaa_timestamp;
+    } else if auction.vaa_timestamp > history.max_timestamp {
+        history.max_timestamp = auction.vaa_timestamp;
+    }
+
+    // Transfer lamports to history account and realloc.
+    let write_index = {
+        let acc_info: &AccountInfo = &ctx.accounts.history;
+
+        let index = acc_info.data_len();
+        let new_len = index + AuctionEntry::INIT_SPACE;
+        let lamport_diff =
+            Rent::get().unwrap().minimum_balance(new_len) - acc_info.try_lamports()?;
+
+        // Transfer lamports
+        system_program::transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                system_program::Transfer {
+                    from: ctx.accounts.payer.to_account_info(),
+                    to: acc_info.to_account_info(),
+                },
+            ),
+            lamport_diff,
+        )?;
+
+        // Realloc.
+        acc_info.realloc(new_len, false)?;
+
+        index
+    };
+
+    // Serialize the header + num entries. This is safe because the underlying data structure for
+    // auction entries is a Vec, whose length is serialized as u32.
+    let acc_data: &mut [_] = &mut ctx.accounts.history.try_borrow_mut_data()?;
+    let mut cursor = std::io::Cursor::new(acc_data);
+    history.try_serialize(&mut cursor)?;
+
+    // This cast is safe since we know the write index is within u32.
+    cursor.set_position(write_index as u64);
+
+    // Serialize entry data.
+    AuctionEntry {
+        vaa_hash: auction.vaa_hash,
+        vaa_timestamp: auction.vaa_timestamp,
+        info,
+    }
+    .serialize(&mut cursor)
+    .map_err(Into::into)
+}

--- a/solana/programs/matching-engine/src/processor/auction/history/create_first.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/create_first.rs
@@ -1,0 +1,29 @@
+use crate::state::AuctionHistory;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct CreateFirstAuctionHistory<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    #[account(
+        init,
+        payer = payer,
+        space = AuctionHistory::START,
+        seeds = [
+            AuctionHistory::SEED_PREFIX,
+            &u64::default().to_be_bytes()
+        ],
+        bump,
+    )]
+    first_history: Account<'info, AuctionHistory>,
+
+    system_program: Program<'info, System>,
+}
+
+pub fn create_first_auction_history(ctx: Context<CreateFirstAuctionHistory>) -> Result<()> {
+    ctx.accounts.first_history.set_inner(Default::default());
+
+    // Done.
+    Ok(())
+}

--- a/solana/programs/matching-engine/src/processor/auction/history/create_new.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/create_new.rs
@@ -44,11 +44,7 @@ pub struct CreateNewAuctionHistory<'info> {
 
 pub fn create_new_auction_history(ctx: Context<CreateNewAuctionHistory>) -> Result<()> {
     ctx.accounts.new_history.set_inner(AuctionHistory {
-        header: AuctionHistoryHeader {
-            id: ctx.accounts.current_history.id + 1,
-            min_timestamp: Default::default(),
-            max_timestamp: Default::default(),
-        },
+        header: AuctionHistoryHeader::new(ctx.accounts.current_history.id + 1),
         data: Default::default(),
     });
 

--- a/solana/programs/matching-engine/src/processor/auction/history/create_new.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/create_new.rs
@@ -1,4 +1,7 @@
-use crate::state::{AuctionHistory, AuctionHistoryHeader, AuctionHistoryInternal};
+use crate::{
+    error::MatchingEngineError,
+    state::{AuctionHistory, AuctionHistoryHeader, AuctionHistoryInternal},
+};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
@@ -14,8 +17,9 @@ pub struct CreateNewAuctionHistory<'info> {
         bump,
         constraint = {
             require_eq!(
-                current_history.num_entries(),
-                AuctionHistory::MAX_ENTRIES, // TODO: add err
+                current_history.num_entries,
+                AuctionHistory::MAX_ENTRIES,
+                MatchingEngineError::AuctionHistoryNotFull,
             );
 
             true

--- a/solana/programs/matching-engine/src/processor/auction/history/create_new.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/create_new.rs
@@ -1,0 +1,53 @@
+use crate::state::{AuctionHistory, AuctionHistoryHeader, AuctionHistoryInternal};
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct CreateNewAuctionHistory<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    #[account(
+        seeds = [
+            AuctionHistory::SEED_PREFIX,
+            &current_history.id.to_be_bytes()
+        ],
+        bump,
+        constraint = {
+            require_eq!(
+                current_history.num_entries(),
+                AuctionHistory::MAX_ENTRIES, // TODO: add err
+            );
+
+            true
+        }
+    )]
+    current_history: Account<'info, AuctionHistoryInternal>,
+
+    #[account(
+        init,
+        payer = payer,
+        space = AuctionHistory::START,
+        seeds = [
+            AuctionHistory::SEED_PREFIX,
+            &(current_history.id + 1).to_be_bytes()
+        ],
+        bump,
+    )]
+    new_history: Account<'info, AuctionHistory>,
+
+    system_program: Program<'info, System>,
+}
+
+pub fn create_new_auction_history(ctx: Context<CreateNewAuctionHistory>) -> Result<()> {
+    ctx.accounts.new_history.set_inner(AuctionHistory {
+        header: AuctionHistoryHeader {
+            id: ctx.accounts.current_history.id + 1,
+            min_timestamp: Default::default(),
+            max_timestamp: Default::default(),
+        },
+        data: Default::default(),
+    });
+
+    // Done.
+    Ok(())
+}

--- a/solana/programs/matching-engine/src/processor/auction/history/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/mod.rs
@@ -1,3 +1,6 @@
+mod add_entry;
+pub use add_entry::*;
+
 mod create_first;
 pub use create_first::*;
 

--- a/solana/programs/matching-engine/src/processor/auction/history/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/history/mod.rs
@@ -1,0 +1,5 @@
+mod create_first;
+pub use create_first::*;
+
+mod create_new;
+pub use create_new::*;

--- a/solana/programs/matching-engine/src/processor/auction/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/mod.rs
@@ -1,6 +1,9 @@
 mod execute_fast_order;
 pub use execute_fast_order::*;
 
+mod history;
+pub(crate) use history::*;
+
 mod offer;
 pub use offer::*;
 

--- a/solana/programs/matching-engine/src/processor/auction/offer/place_initial.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/place_initial.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anchor_lang::prelude::*;
 use anchor_spl::token;
-use common::{constants::VAA_AUCTION_EXPIRATION_TIME, messages::raw::LiquidityLayerMessage};
+use common::messages::raw::LiquidityLayerMessage;
 
 #[derive(Accounts)]
 #[instruction(offer_price: u64)]
@@ -106,7 +106,7 @@ pub fn place_initial_offer(ctx: Context<PlaceInitialOffer>, offer_price: u64) ->
         let vaa_timestamp = fast_vaa.timestamp();
         require!(
             (deadline == 0 || unix_timestamp < deadline)
-                && unix_timestamp < (vaa_timestamp + VAA_AUCTION_EXPIRATION_TIME).into(),
+                && unix_timestamp < (vaa_timestamp + crate::VAA_AUCTION_EXPIRATION_TIME).into(),
             MatchingEngineError::FastMarketOrderExpired,
         );
 
@@ -128,12 +128,12 @@ pub fn place_initial_offer(ctx: Context<PlaceInitialOffer>, offer_price: u64) ->
     ctx.accounts.auction.set_inner(Auction {
         bump: ctx.bumps.auction,
         vaa_hash,
+        vaa_timestamp,
         status: AuctionStatus::Active,
         info: Some(AuctionInfo {
             config_id: ctx.accounts.auction_config.id,
             custody_token_bump: ctx.bumps.auction_custody_token,
             vaa_sequence: fast_vaa.sequence(),
-            vaa_timestamp,
             source_chain,
             best_offer_token: initial_offer_token,
             initial_offer_token,

--- a/solana/programs/matching-engine/src/processor/auction/settle/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/mod.rs
@@ -1,6 +1,3 @@
-// mod active;
-// pub use active::*;
-
 mod complete;
 pub use complete::*;
 

--- a/solana/programs/matching-engine/src/processor/auction/settle/none/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/none/mod.rs
@@ -95,6 +95,7 @@ fn settle_none_and_prepare_fill(
     auction.set_inner(Auction {
         bump: auction_bump_seed,
         vaa_hash: fast_vaa.digest().0,
+        vaa_timestamp: fast_vaa.timestamp(),
         status: AuctionStatus::Settled {
             base_fee,
             total_penalty: None,

--- a/solana/programs/matching-engine/src/state/auction.rs
+++ b/solana/programs/matching-engine/src/state/auction.rs
@@ -43,7 +43,7 @@ impl std::fmt::Display for AuctionStatus {
     }
 }
 
-#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Copy)]
 pub struct AuctionInfo {
     pub config_id: u32,
 
@@ -51,9 +51,6 @@ pub struct AuctionInfo {
 
     /// Sequence of the fast market order VAA.
     pub vaa_sequence: u64,
-
-    /// Timestamp of the fast market order VAA.
-    pub vaa_timestamp: u32,
 
     /// The chain where the transfer is initiated.
     pub source_chain: u16,
@@ -115,6 +112,9 @@ pub struct Auction {
 
     /// VAA hash of the auction.
     pub vaa_hash: [u8; 32],
+
+    /// Timestamp of the fast market order VAA.
+    pub vaa_timestamp: u32,
 
     /// Auction status.
     pub status: AuctionStatus,

--- a/solana/programs/matching-engine/src/state/auction.rs
+++ b/solana/programs/matching-engine/src/state/auction.rs
@@ -52,6 +52,9 @@ pub struct AuctionInfo {
     /// Sequence of the fast market order VAA.
     pub vaa_sequence: u64,
 
+    /// Timestamp of the fast market order VAA.
+    pub vaa_timestamp: u32,
+
     /// The chain where the transfer is initiated.
     pub source_chain: u16,
 

--- a/solana/programs/matching-engine/src/state/auction_history.rs
+++ b/solana/programs/matching-engine/src/state/auction_history.rs
@@ -34,8 +34,18 @@ pub struct AuctionEntry {
 #[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Default)]
 pub struct AuctionHistoryHeader {
     pub id: u64,
-    pub min_timestamp: u32,
-    pub max_timestamp: u32,
+    pub min_timestamp: Option<u32>,
+    pub max_timestamp: Option<u32>,
+}
+
+impl AuctionHistoryHeader {
+    pub fn new(id: u64) -> Self {
+        Self {
+            id,
+            min_timestamp: Default::default(),
+            max_timestamp: Default::default(),
+        }
+    }
 }
 
 impl AuctionHistory {

--- a/solana/programs/matching-engine/src/state/auction_history.rs
+++ b/solana/programs/matching-engine/src/state/auction_history.rs
@@ -1,0 +1,145 @@
+//! The auction history state does not follow the same pattern as the other account schemas. Because
+//! we do not lean on [AccountSerialize] and [AccountDeserialize] in account contexts for the full
+//! auction history, we will be using a header to perform these operations to validate just the
+//! beginning of each of these accounts. The history itself will be read in using [AccountInfo].
+
+use std::ops::Deref;
+
+use anchor_lang::prelude::*;
+
+use super::AuctionInfo;
+
+#[account]
+#[derive(Debug, Default)]
+pub struct AuctionHistory {
+    pub header: AuctionHistoryHeader,
+    pub data: Vec<AuctionEntry>,
+}
+
+impl Deref for AuctionHistory {
+    type Target = AuctionHistoryHeader;
+
+    fn deref(&self) -> &Self::Target {
+        &self.header
+    }
+}
+
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct AuctionEntry {
+    pub vaa_hash: [u8; 32],
+    pub info: AuctionInfo,
+}
+
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, InitSpace, Default)]
+pub struct AuctionHistoryHeader {
+    pub id: u64,
+    pub min_timestamp: u32,
+    pub max_timestamp: u32,
+}
+
+impl AuctionHistory {
+    pub const SEED_PREFIX: &'static [u8] = b"auction-history";
+
+    pub const START: usize = 8 + AuctionHistoryHeader::INIT_SPACE + 4;
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "integration-test")] {
+            pub const MAX_ENTRIES: usize = 2;
+        } else {
+            pub const MAX_ENTRIES: usize = (10 * 1024 * 1000 - Self::START) / AuctionEntry::INIT_SPACE;
+        }
+    }
+}
+
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct AuctionHistoryInternal(AuctionHistoryHeader, u32);
+
+impl AuctionHistoryInternal {
+    pub fn num_entries(&self) -> usize {
+        usize::try_from(self.1).unwrap()
+    }
+}
+
+impl AccountDeserialize for AuctionHistoryInternal {
+    fn try_deserialize(buf: &mut &[u8]) -> Result<Self> {
+        if buf[..8] != <AuctionHistory as anchor_lang::Discriminator>::DISCRIMINATOR {
+            err!(ErrorCode::AccountDiscriminatorMismatch)
+        } else {
+            Self::try_deserialize_unchecked(buf)
+        }
+    }
+
+    fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self> {
+        *buf = &mut &buf[8..];
+        Ok(Self(
+            AnchorDeserialize::deserialize(buf)?,
+            AnchorDeserialize::deserialize(buf)?,
+        ))
+    }
+}
+
+impl AccountSerialize for AuctionHistoryInternal {}
+
+impl Owner for AuctionHistoryInternal {
+    fn owner() -> Pubkey {
+        crate::id()
+    }
+}
+
+impl Deref for AuctionHistoryInternal {
+    type Target = AuctionHistoryHeader;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// pub fn insert_auction_entry(
+//     auction_history: &mut Account<AuctionHistory>,
+//     payer: &Signer,
+//     system_program: &Program<System>,
+//     entry: AuctionEntry,
+// ) -> Result<()> {
+//     auction_history.header.num_entries += 1;
+
+//     let n = auction_history.header.num_entries;
+//     if n > MAX_ENTRIES as u32 {
+//         return err!(ErrorCode::InstructionMissing);
+//     }
+
+//     {
+//         let acc_info: &AccountInfo = auction_history.as_ref();
+
+//         let new_len = usize::try_from(n)
+//             .map(|n| START + n * AuctionEntry::INIT_SPACE)
+//             .unwrap();
+//         let lamport_diff =
+//             Rent::get().unwrap().minimum_balance(new_len) - acc_info.try_lamports()?;
+
+//         // Transfer lamports
+//         system_program::transfer(
+//             CpiContext::new(
+//                 system_program.to_account_info(),
+//                 system_program::Transfer {
+//                     from: payer.to_account_info(),
+//                     to: acc_info.to_account_info(),
+//                 },
+//             ),
+//             lamport_diff,
+//         )?;
+
+//         // Realloc.
+//         acc_info.realloc(new_len, false)?;
+//     }
+
+//     let mut data: &mut [_] = &mut acc_info.try_borrow_mut_data()?;
+
+//     let i = usize::try_from(auction_history.header.num_entries)
+//         .map(|i| i + AuctionEntry::INIT_SPACE + START)
+//         .unwrap();
+//     data = &mut data[i..(i + AuctionEntry::INIT_SPACE)];
+//     entry.serialize(&mut data)?;
+
+//     auction_history.header.num_entries += 1;
+//     Ok(())
+// }

--- a/solana/programs/matching-engine/src/state/mod.rs
+++ b/solana/programs/matching-engine/src/state/mod.rs
@@ -1,10 +1,13 @@
+mod auction;
+pub use auction::*;
+
 mod auction_config;
 pub use auction_config::*;
 
-pub(crate) mod auction;
-pub use auction::*;
+mod auction_history;
+pub use auction_history::*;
 
-pub(crate) mod custodian;
+mod custodian;
 pub use custodian::*;
 
 mod payer_sequence;

--- a/solana/programs/matching-engine/src/utils/auction.rs
+++ b/solana/programs/matching-engine/src/utils/auction.rs
@@ -330,6 +330,7 @@ mod test {
                 security_deposit,
                 custody_token_bump: Default::default(),
                 vaa_sequence: Default::default(),
+                vaa_timestamp: Default::default(),
                 start_slot: START,
                 config_id: Default::default(),
                 source_chain: Default::default(),

--- a/solana/programs/matching-engine/src/utils/auction.rs
+++ b/solana/programs/matching-engine/src/utils/auction.rs
@@ -1,9 +1,9 @@
+use crate::FEE_PRECISION_MAX;
 use crate::{
     error::MatchingEngineError,
     state::{AuctionInfo, AuctionParameters},
 };
 use anchor_lang::prelude::*;
-use common::constants::FEE_PRECISION_MAX;
 
 #[derive(Debug, Default)]
 pub struct DepositPenalty {
@@ -223,8 +223,8 @@ mod test {
     #[test]
     fn initial_penalty_max_user_penalty_half() {
         let params = AuctionParameters {
-            user_penalty_reward_bps: common::constants::FEE_PRECISION_MAX / 2,
-            initial_penalty_bps: common::constants::FEE_PRECISION_MAX,
+            user_penalty_reward_bps: FEE_PRECISION_MAX / 2,
+            initial_penalty_bps: FEE_PRECISION_MAX,
             ..params_for_test()
         };
 
@@ -244,8 +244,8 @@ mod test {
     #[test]
     fn user_penalty_max_initial_penalty_half() {
         let params = AuctionParameters {
-            user_penalty_reward_bps: common::constants::FEE_PRECISION_MAX,
-            initial_penalty_bps: common::constants::FEE_PRECISION_MAX / 2,
+            user_penalty_reward_bps: FEE_PRECISION_MAX,
+            initial_penalty_bps: FEE_PRECISION_MAX / 2,
             ..params_for_test()
         };
 
@@ -265,8 +265,8 @@ mod test {
     #[test]
     fn penalty_slots_zero() {
         let params = AuctionParameters {
-            user_penalty_reward_bps: common::constants::FEE_PRECISION_MAX / 2,
-            initial_penalty_bps: common::constants::FEE_PRECISION_MAX / 2,
+            user_penalty_reward_bps: FEE_PRECISION_MAX / 2,
+            initial_penalty_bps: FEE_PRECISION_MAX / 2,
             penalty_period: 0,
             ..params_for_test()
         };
@@ -287,7 +287,7 @@ mod test {
     #[test]
     fn compute_min_offer_delta_max() {
         let mut params = params_for_test();
-        params.min_offer_delta_bps = common::constants::FEE_PRECISION_MAX;
+        params.min_offer_delta_bps = FEE_PRECISION_MAX;
 
         let offer_price = 10000000;
         let (info, _) = set_up(0, None, offer_price);
@@ -330,7 +330,6 @@ mod test {
                 security_deposit,
                 custody_token_bump: Default::default(),
                 vaa_sequence: Default::default(),
-                vaa_timestamp: Default::default(),
                 start_slot: START,
                 config_id: Default::default(),
                 source_chain: Default::default(),

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -2287,6 +2287,22 @@
     },
     {
       "name": "addAuctionHistoryEntry",
+      "docs": [
+        "This instruction is used to add a new entry to the `AuctionHistory` account if there is an",
+        "`Auction` with some info. Regardless of whether there is info in this account, the",
+        "instruction finishes its operation by closing this auction account. If the history account",
+        "is full, this instruction will revert and `create_new_auction_history`` will have to be",
+        "called to initialize another history account.",
+        "",
+        "This mechanism is important for auction participants. The initial offer participant will",
+        "pay lamports to create the `Auction` account. This instruction allows him to reclaim some",
+        "lamports by closing that account. And the protocol's fee recipient will be able to claim",
+        "lamports by closing the empty `Auction` account it creates when he calls any of the",
+        "`settle_auction_none_*` instructions.",
+        "# Arguments",
+        "",
+        "* `ctx` - `AddAuctionHistoryEntry` context."
+      ],
       "accounts": [
         {
           "name": "payer",

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -3179,5 +3179,8 @@
       "code": 7284,
       "name": "AuctionHistoryFull"
     }
-  ]
+  ],
+  "metadata": {
+    "address": "MatchingEngine11111111111111111111111111111"
+  }
 }

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -2222,6 +2222,68 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "createFirstAuctionHistory",
+      "docs": [
+        "This instruction is used to create the first `AuctionHistory` account, whose PDA is derived",
+        "using ID == 0.",
+        "# Arguments",
+        "",
+        "* `ctx` - `CreateFirstAuctionHistory` context."
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "firstHistory",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "createNewAuctionHistory",
+      "docs": [
+        "This instruction is used to create a new `AuctionHistory` account. The PDA is derived using",
+        "its ID. A new history account can be created only when the current one is full (number of",
+        "entries equals the hard-coded max entries).",
+        "# Arguments",
+        "",
+        "* `ctx` - `CreateNewAuctionHistory` context."
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "currentHistory",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newHistory",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -2238,6 +2300,28 @@
             "name": "parameters",
             "type": {
               "defined": "AuctionParameters"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuctionHistory",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": "AuctionHistoryHeader"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "vec": {
+                "defined": "AuctionEntry"
+              }
             }
           }
         ]
@@ -2559,6 +2643,49 @@
       }
     },
     {
+      "name": "AuctionEntry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "info",
+            "type": {
+              "defined": "AuctionInfo"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuctionHistoryHeader",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "minTimestamp",
+            "type": "u32"
+          },
+          {
+            "name": "maxTimestamp",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
       "name": "AuctionInfo",
       "type": {
         "kind": "struct",
@@ -2577,6 +2704,13 @@
               "Sequence of the fast market order VAA."
             ],
             "type": "u64"
+          },
+          {
+            "name": "vaaTimestamp",
+            "docs": [
+              "Timestamp of the fast market order VAA."
+            ],
+            "type": "u32"
           },
           {
             "name": "sourceChain",
@@ -2951,8 +3085,5 @@
       "code": 7054,
       "name": "CarpingNotAllowed"
     }
-  ],
-  "metadata": {
-    "address": "MatchingEngine11111111111111111111111111111"
-  }
+  ]
 }

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -2739,11 +2739,15 @@
           },
           {
             "name": "minTimestamp",
-            "type": "u32"
+            "type": {
+              "option": "u32"
+            }
           },
           {
             "name": "maxTimestamp",
-            "type": "u32"
+            "type": {
+              "option": "u32"
+            }
           }
         ]
       }

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -2284,6 +2284,58 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "addAuctionHistoryEntry",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "custodian",
+          "accounts": [
+            {
+              "name": "custodian",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "history",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "because we will be writing to this account without using Anchor's [AccountsExit]."
+          ]
+        },
+        {
+          "name": "auction",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "beneficiary",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "was no auction) or the owner of the initial offer token account."
+          ]
+        },
+        {
+          "name": "beneficiaryToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -2347,6 +2399,13 @@
                 32
               ]
             }
+          },
+          {
+            "name": "vaaTimestamp",
+            "docs": [
+              "Timestamp of the fast market order VAA."
+            ],
+            "type": "u32"
           },
           {
             "name": "status",
@@ -2657,6 +2716,10 @@
             }
           },
           {
+            "name": "vaaTimestamp",
+            "type": "u32"
+          },
+          {
             "name": "info",
             "type": {
               "defined": "AuctionInfo"
@@ -2686,6 +2749,24 @@
       }
     },
     {
+      "name": "AuctionHistoryInternal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": "AuctionHistoryHeader"
+            }
+          },
+          {
+            "name": "numEntries",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
       "name": "AuctionInfo",
       "type": {
         "kind": "struct",
@@ -2704,13 +2785,6 @@
               "Sequence of the fast market order VAA."
             ],
             "type": "u64"
-          },
-          {
-            "name": "vaaTimestamp",
-            "docs": [
-              "Timestamp of the fast market order VAA."
-            ],
-            "type": "u32"
           },
           {
             "name": "sourceChain",
@@ -3084,6 +3158,22 @@
     {
       "code": 7054,
       "name": "CarpingNotAllowed"
+    },
+    {
+      "code": 7056,
+      "name": "AuctionNotSettled"
+    },
+    {
+      "code": 7280,
+      "name": "CannotCloseAuctionYet"
+    },
+    {
+      "code": 7282,
+      "name": "AuctionHistoryNotFull"
+    },
+    {
+      "code": 7284,
+      "name": "AuctionHistoryFull"
     }
   ]
 }

--- a/solana/target/idl/token_router.json
+++ b/solana/target/idl/token_router.json
@@ -1430,5 +1430,8 @@
       "code": 7038,
       "name": "PayerNotPreparer"
     }
-  ]
+  ],
+  "metadata": {
+    "address": "TokenRouter11111111111111111111111111111111"
+  }
 }

--- a/solana/target/idl/token_router.json
+++ b/solana/target/idl/token_router.json
@@ -1430,8 +1430,5 @@
       "code": 7038,
       "name": "PayerNotPreparer"
     }
-  ],
-  "metadata": {
-    "address": "TokenRouter11111111111111111111111111111111"
-  }
+  ]
 }

--- a/solana/target/idl/upgrade_manager.json
+++ b/solana/target/idl/upgrade_manager.json
@@ -398,5 +398,8 @@
       "code": 6020,
       "name": "OwnerMismatch"
     }
-  ]
+  ],
+  "metadata": {
+    "address": "UpgradeManager11111111111111111111111111111"
+  }
 }

--- a/solana/target/idl/upgrade_manager.json
+++ b/solana/target/idl/upgrade_manager.json
@@ -398,8 +398,5 @@
       "code": 6020,
       "name": "OwnerMismatch"
     }
-  ],
-  "metadata": {
-    "address": "UpgradeManager11111111111111111111111111111"
-  }
+  ]
 }

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -2287,6 +2287,22 @@ export type MatchingEngine = {
     },
     {
       "name": "addAuctionHistoryEntry",
+      "docs": [
+        "This instruction is used to add a new entry to the `AuctionHistory` account if there is an",
+        "`Auction` with some info. Regardless of whether there is info in this account, the",
+        "instruction finishes its operation by closing this auction account. If the history account",
+        "is full, this instruction will revert and `create_new_auction_history`` will have to be",
+        "called to initialize another history account.",
+        "",
+        "This mechanism is important for auction participants. The initial offer participant will",
+        "pay lamports to create the `Auction` account. This instruction allows him to reclaim some",
+        "lamports by closing that account. And the protocol's fee recipient will be able to claim",
+        "lamports by closing the empty `Auction` account it creates when he calls any of the",
+        "`settle_auction_none_*` instructions.",
+        "# Arguments",
+        "",
+        "* `ctx` - `AddAuctionHistoryEntry` context."
+      ],
       "accounts": [
         {
           "name": "payer",
@@ -5471,6 +5487,22 @@ export const IDL: MatchingEngine = {
     },
     {
       "name": "addAuctionHistoryEntry",
+      "docs": [
+        "This instruction is used to add a new entry to the `AuctionHistory` account if there is an",
+        "`Auction` with some info. Regardless of whether there is info in this account, the",
+        "instruction finishes its operation by closing this auction account. If the history account",
+        "is full, this instruction will revert and `create_new_auction_history`` will have to be",
+        "called to initialize another history account.",
+        "",
+        "This mechanism is important for auction participants. The initial offer participant will",
+        "pay lamports to create the `Auction` account. This instruction allows him to reclaim some",
+        "lamports by closing that account. And the protocol's fee recipient will be able to claim",
+        "lamports by closing the empty `Auction` account it creates when he calls any of the",
+        "`settle_auction_none_*` instructions.",
+        "# Arguments",
+        "",
+        "* `ctx` - `AddAuctionHistoryEntry` context."
+      ],
       "accounts": [
         {
           "name": "payer",

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -2284,6 +2284,58 @@ export type MatchingEngine = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "addAuctionHistoryEntry",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "custodian",
+          "accounts": [
+            {
+              "name": "custodian",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "history",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "because we will be writing to this account without using Anchor's [AccountsExit]."
+          ]
+        },
+        {
+          "name": "auction",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "beneficiary",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "was no auction) or the owner of the initial offer token account."
+          ]
+        },
+        {
+          "name": "beneficiaryToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -2347,6 +2399,13 @@ export type MatchingEngine = {
                 32
               ]
             }
+          },
+          {
+            "name": "vaaTimestamp",
+            "docs": [
+              "Timestamp of the fast market order VAA."
+            ],
+            "type": "u32"
           },
           {
             "name": "status",
@@ -2657,6 +2716,10 @@ export type MatchingEngine = {
             }
           },
           {
+            "name": "vaaTimestamp",
+            "type": "u32"
+          },
+          {
             "name": "info",
             "type": {
               "defined": "AuctionInfo"
@@ -2686,6 +2749,24 @@ export type MatchingEngine = {
       }
     },
     {
+      "name": "AuctionHistoryInternal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": "AuctionHistoryHeader"
+            }
+          },
+          {
+            "name": "numEntries",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
       "name": "AuctionInfo",
       "type": {
         "kind": "struct",
@@ -2704,13 +2785,6 @@ export type MatchingEngine = {
               "Sequence of the fast market order VAA."
             ],
             "type": "u64"
-          },
-          {
-            "name": "vaaTimestamp",
-            "docs": [
-              "Timestamp of the fast market order VAA."
-            ],
-            "type": "u32"
           },
           {
             "name": "sourceChain",
@@ -3084,6 +3158,22 @@ export type MatchingEngine = {
     {
       "code": 7054,
       "name": "CarpingNotAllowed"
+    },
+    {
+      "code": 7056,
+      "name": "AuctionNotSettled"
+    },
+    {
+      "code": 7280,
+      "name": "CannotCloseAuctionYet"
+    },
+    {
+      "code": 7282,
+      "name": "AuctionHistoryNotFull"
+    },
+    {
+      "code": 7284,
+      "name": "AuctionHistoryFull"
     }
   ]
 };
@@ -5374,6 +5464,58 @@ export const IDL: MatchingEngine = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "addAuctionHistoryEntry",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "custodian",
+          "accounts": [
+            {
+              "name": "custodian",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "history",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "because we will be writing to this account without using Anchor's [AccountsExit]."
+          ]
+        },
+        {
+          "name": "auction",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "beneficiary",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "was no auction) or the owner of the initial offer token account."
+          ]
+        },
+        {
+          "name": "beneficiaryToken",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -5437,6 +5579,13 @@ export const IDL: MatchingEngine = {
                 32
               ]
             }
+          },
+          {
+            "name": "vaaTimestamp",
+            "docs": [
+              "Timestamp of the fast market order VAA."
+            ],
+            "type": "u32"
           },
           {
             "name": "status",
@@ -5747,6 +5896,10 @@ export const IDL: MatchingEngine = {
             }
           },
           {
+            "name": "vaaTimestamp",
+            "type": "u32"
+          },
+          {
             "name": "info",
             "type": {
               "defined": "AuctionInfo"
@@ -5776,6 +5929,24 @@ export const IDL: MatchingEngine = {
       }
     },
     {
+      "name": "AuctionHistoryInternal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": "AuctionHistoryHeader"
+            }
+          },
+          {
+            "name": "numEntries",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
       "name": "AuctionInfo",
       "type": {
         "kind": "struct",
@@ -5794,13 +5965,6 @@ export const IDL: MatchingEngine = {
               "Sequence of the fast market order VAA."
             ],
             "type": "u64"
-          },
-          {
-            "name": "vaaTimestamp",
-            "docs": [
-              "Timestamp of the fast market order VAA."
-            ],
-            "type": "u32"
           },
           {
             "name": "sourceChain",
@@ -6174,6 +6338,22 @@ export const IDL: MatchingEngine = {
     {
       "code": 7054,
       "name": "CarpingNotAllowed"
+    },
+    {
+      "code": 7056,
+      "name": "AuctionNotSettled"
+    },
+    {
+      "code": 7280,
+      "name": "CannotCloseAuctionYet"
+    },
+    {
+      "code": 7282,
+      "name": "AuctionHistoryNotFull"
+    },
+    {
+      "code": 7284,
+      "name": "AuctionHistoryFull"
     }
   ]
 };

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -2739,11 +2739,15 @@ export type MatchingEngine = {
           },
           {
             "name": "minTimestamp",
-            "type": "u32"
+            "type": {
+              "option": "u32"
+            }
           },
           {
             "name": "maxTimestamp",
-            "type": "u32"
+            "type": {
+              "option": "u32"
+            }
           }
         ]
       }
@@ -5919,11 +5923,15 @@ export const IDL: MatchingEngine = {
           },
           {
             "name": "minTimestamp",
-            "type": "u32"
+            "type": {
+              "option": "u32"
+            }
           },
           {
             "name": "maxTimestamp",
-            "type": "u32"
+            "type": {
+              "option": "u32"
+            }
           }
         ]
       }

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -2222,6 +2222,68 @@ export type MatchingEngine = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "createFirstAuctionHistory",
+      "docs": [
+        "This instruction is used to create the first `AuctionHistory` account, whose PDA is derived",
+        "using ID == 0.",
+        "# Arguments",
+        "",
+        "* `ctx` - `CreateFirstAuctionHistory` context."
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "firstHistory",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "createNewAuctionHistory",
+      "docs": [
+        "This instruction is used to create a new `AuctionHistory` account. The PDA is derived using",
+        "its ID. A new history account can be created only when the current one is full (number of",
+        "entries equals the hard-coded max entries).",
+        "# Arguments",
+        "",
+        "* `ctx` - `CreateNewAuctionHistory` context."
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "currentHistory",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newHistory",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -2238,6 +2300,28 @@ export type MatchingEngine = {
             "name": "parameters",
             "type": {
               "defined": "AuctionParameters"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "auctionHistory",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": "AuctionHistoryHeader"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "vec": {
+                "defined": "AuctionEntry"
+              }
             }
           }
         ]
@@ -2559,6 +2643,49 @@ export type MatchingEngine = {
       }
     },
     {
+      "name": "AuctionEntry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "info",
+            "type": {
+              "defined": "AuctionInfo"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuctionHistoryHeader",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "minTimestamp",
+            "type": "u32"
+          },
+          {
+            "name": "maxTimestamp",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
       "name": "AuctionInfo",
       "type": {
         "kind": "struct",
@@ -2577,6 +2704,13 @@ export type MatchingEngine = {
               "Sequence of the fast market order VAA."
             ],
             "type": "u64"
+          },
+          {
+            "name": "vaaTimestamp",
+            "docs": [
+              "Timestamp of the fast market order VAA."
+            ],
+            "type": "u32"
           },
           {
             "name": "sourceChain",
@@ -5178,6 +5312,68 @@ export const IDL: MatchingEngine = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "createFirstAuctionHistory",
+      "docs": [
+        "This instruction is used to create the first `AuctionHistory` account, whose PDA is derived",
+        "using ID == 0.",
+        "# Arguments",
+        "",
+        "* `ctx` - `CreateFirstAuctionHistory` context."
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "firstHistory",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "createNewAuctionHistory",
+      "docs": [
+        "This instruction is used to create a new `AuctionHistory` account. The PDA is derived using",
+        "its ID. A new history account can be created only when the current one is full (number of",
+        "entries equals the hard-coded max entries).",
+        "# Arguments",
+        "",
+        "* `ctx` - `CreateNewAuctionHistory` context."
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "currentHistory",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newHistory",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -5194,6 +5390,28 @@ export const IDL: MatchingEngine = {
             "name": "parameters",
             "type": {
               "defined": "AuctionParameters"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "auctionHistory",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": "AuctionHistoryHeader"
+            }
+          },
+          {
+            "name": "data",
+            "type": {
+              "vec": {
+                "defined": "AuctionEntry"
+              }
             }
           }
         ]
@@ -5515,6 +5733,49 @@ export const IDL: MatchingEngine = {
       }
     },
     {
+      "name": "AuctionEntry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "info",
+            "type": {
+              "defined": "AuctionInfo"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuctionHistoryHeader",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "minTimestamp",
+            "type": "u32"
+          },
+          {
+            "name": "maxTimestamp",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
       "name": "AuctionInfo",
       "type": {
         "kind": "struct",
@@ -5533,6 +5794,13 @@ export const IDL: MatchingEngine = {
               "Sequence of the fast market order VAA."
             ],
             "type": "u64"
+          },
+          {
+            "name": "vaaTimestamp",
+            "docs": [
+              "Timestamp of the fast market order VAA."
+            ],
+            "type": "u32"
           },
           {
             "name": "sourceChain",

--- a/solana/ts/src/common/index.ts
+++ b/solana/ts/src/common/index.ts
@@ -1,8 +1,41 @@
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import { MessageTransmitterProgram } from "../cctp";
+import { BN } from "@coral-xyz/anchor";
 
 export * from "./messages";
 export * from "./state";
+
+export type Uint64 = bigint | BN | number;
+
+export function isUint64(value: Uint64): boolean {
+    return (
+        typeof value === "bigint" ||
+        (typeof value === "object" && value instanceof BN) ||
+        typeof value === "number"
+    );
+}
+
+export function uint64ToBigInt(value: Uint64): bigint {
+    if (typeof value === "bigint") {
+        return value;
+    } else if (typeof value === "number") {
+        return BigInt(value);
+    } else if (value.byteLength() <= 8) {
+        return BigInt(value.toString());
+    } else {
+        throw new Error("Invalid uint64");
+    }
+}
+
+export function writeUint64BE(buf: Buffer, value: Uint64, offset?: number) {
+    return buf.writeBigUInt64BE(uint64ToBigInt(value), offset);
+}
+
+export function uint64ToBN(value: Uint64): BN {
+    const buf = Buffer.alloc(8);
+    writeUint64BE(buf, value);
+    return new BN(buf);
+}
 
 export async function reclaimCctpMessageIx(
     messageTransmitter: MessageTransmitterProgram,

--- a/solana/ts/src/common/state/index.ts
+++ b/solana/ts/src/common/state/index.ts
@@ -10,7 +10,7 @@ export function emitterAddress(programId: PublicKey): PublicKey {
 export function coreMessageAddress(
     programId: PublicKey,
     payer: PublicKey,
-    payerSequenceValue: BN | bigint,
+    payerSequenceValue: Uint64,
 ): PublicKey {
     return messageAddress(programId, payer, payerSequenceValue, "core-msg");
 }
@@ -18,7 +18,7 @@ export function coreMessageAddress(
 export function cctpMessageAddress(
     programId: PublicKey,
     payer: PublicKey,
-    payerSequenceValue: BN | bigint,
+    payerSequenceValue: Uint64,
 ): PublicKey {
     return messageAddress(programId, payer, payerSequenceValue, "cctp-msg");
 }
@@ -26,7 +26,7 @@ export function cctpMessageAddress(
 function messageAddress(
     programId: PublicKey,
     payer: PublicKey,
-    payerSequenceValue: BN | bigint,
+    payerSequenceValue: Uint64,
     prefix: string,
 ): PublicKey {
     const encodedPayerSequenceValue = Buffer.alloc(8);

--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -940,9 +940,11 @@ export class MatchingEngineProgram {
             auctionConfig?: PublicKey;
             fromRouterEndpoint?: PublicKey;
             toRouterEndpoint?: PublicKey;
+        },
+        args: {
+            offerPrice: bigint;
             totalDeposit?: bigint;
         },
-        offerPrice: bigint,
     ): Promise<[approveIx: TransactionInstruction, placeInitialOfferIx: TransactionInstruction]> {
         const {
             payer,
@@ -952,8 +954,9 @@ export class MatchingEngineProgram {
             auctionConfig: inputAuctionConfig,
             fromRouterEndpoint: inputFromRouterEndpoint,
             toRouterEndpoint: inputToRouterEndpoint,
-            totalDeposit: inputTotalDeposit,
         } = accounts;
+
+        const { offerPrice, totalDeposit: inputTotalDeposit } = args;
 
         const offerToken = await (async () => {
             if (inputOfferToken !== undefined) {

--- a/solana/ts/src/matchingEngine/state/Auction.ts
+++ b/solana/ts/src/matchingEngine/state/Auction.ts
@@ -15,6 +15,7 @@ export type AuctionInfo = {
     configId: number;
     custodyTokenBump: number;
     vaaSequence: BN;
+    vaaTimestamp: number;
     sourceChain: number;
     bestOfferToken: PublicKey;
     initialOfferToken: PublicKey;

--- a/solana/ts/src/matchingEngine/state/Auction.ts
+++ b/solana/ts/src/matchingEngine/state/Auction.ts
@@ -15,7 +15,6 @@ export type AuctionInfo = {
     configId: number;
     custodyTokenBump: number;
     vaaSequence: BN;
-    vaaTimestamp: number;
     sourceChain: number;
     bestOfferToken: PublicKey;
     initialOfferToken: PublicKey;
@@ -29,12 +28,20 @@ export type AuctionInfo = {
 export class Auction {
     bump: number;
     vaaHash: number[];
+    vaaTimestamp: number;
     status: AuctionStatus;
     info: AuctionInfo | null;
 
-    constructor(bump: number, vaaHash: number[], status: AuctionStatus, info: AuctionInfo | null) {
+    constructor(
+        bump: number,
+        vaaHash: number[],
+        vaaTimestamp: number,
+        status: AuctionStatus,
+        info: AuctionInfo | null,
+    ) {
         this.bump = bump;
         this.vaaHash = vaaHash;
+        this.vaaTimestamp = vaaTimestamp;
         this.status = status;
         this.info = info;
     }

--- a/solana/ts/src/matchingEngine/state/AuctionHistory.ts
+++ b/solana/ts/src/matchingEngine/state/AuctionHistory.ts
@@ -5,12 +5,13 @@ import { Uint64, writeUint64BE } from "../../common";
 
 export type AuctionHistoryHeader = {
     id: BN;
-    minTimestamp: number;
-    maxTimestamp: number;
+    minTimestamp: number | null;
+    maxTimestamp: number | null;
 };
 
 export type AuctionEntry = {
     vaaHash: Array<number>;
+    vaaTimestamp: number;
     info: AuctionInfo;
 };
 

--- a/solana/ts/src/matchingEngine/state/AuctionHistory.ts
+++ b/solana/ts/src/matchingEngine/state/AuctionHistory.ts
@@ -1,0 +1,34 @@
+import { BN } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { AuctionInfo } from "./Auction";
+import { Uint64, writeUint64BE } from "../../common";
+
+export type AuctionHistoryHeader = {
+    id: BN;
+    minTimestamp: number;
+    maxTimestamp: number;
+};
+
+export type AuctionEntry = {
+    vaaHash: Array<number>;
+    info: AuctionInfo;
+};
+
+export class AuctionHistory {
+    header: AuctionHistoryHeader;
+    data: Array<AuctionEntry>;
+
+    constructor(header: AuctionHistoryHeader, data: Array<AuctionEntry>) {
+        this.header = header;
+        this.data = data;
+    }
+
+    static address(programId: PublicKey, id: Uint64) {
+        const encodedId = Buffer.alloc(8);
+        writeUint64BE(encodedId, id);
+        return PublicKey.findProgramAddressSync(
+            [Buffer.from("auction-history"), encodedId],
+            programId,
+        )[0];
+    }
+}

--- a/solana/ts/src/matchingEngine/state/index.ts
+++ b/solana/ts/src/matchingEngine/state/index.ts
@@ -1,5 +1,6 @@
 export * from "./Auction";
 export * from "./AuctionConfig";
+export * from "./AuctionHistory";
 export * from "./Custodian";
 export * from "./PreparedOrderResponse";
 export * from "./Proposal";

--- a/solana/ts/src/tokenRouter/index.ts
+++ b/solana/ts/src/tokenRouter/index.ts
@@ -17,6 +17,7 @@ import {
     TokenMessengerMinterProgram,
 } from "../cctp";
 import {
+    Uint64,
     PayerSequence,
     cctpMessageAddress,
     coreMessageAddress,
@@ -155,11 +156,11 @@ export class TokenRouterProgram {
         )[0];
     }
 
-    coreMessageAddress(payer: PublicKey, payerSequenceValue: BN | bigint): PublicKey {
+    coreMessageAddress(payer: PublicKey, payerSequenceValue: Uint64): PublicKey {
         return coreMessageAddress(this.ID, payer, payerSequenceValue);
     }
 
-    cctpMessageAddress(payer: PublicKey, payerSequenceValue: BN | bigint): PublicKey {
+    cctpMessageAddress(payer: PublicKey, payerSequenceValue: Uint64): PublicKey {
         return cctpMessageAddress(this.ID, payer, payerSequenceValue);
     }
 

--- a/solana/ts/src/wormhole/index.ts
+++ b/solana/ts/src/wormhole/index.ts
@@ -108,6 +108,16 @@ export class VaaAccount {
         }
     }
 
+    timestamp(): number {
+        if (this._encodedVaa !== undefined) {
+            return parseVaa(this._encodedVaa.buf).timestamp;
+        } else if (this._postedVaaV1 !== undefined) {
+            return this._postedVaaV1.timestamp;
+        } else {
+            throw new Error("impossible: timestamp() failed");
+        }
+    }
+
     payload(): Buffer {
         if (this._encodedVaa !== undefined) {
             return parseVaa(this._encodedVaa.buf).payload;

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -1893,12 +1893,11 @@ describe("Matching Engine", function () {
                     newOfferAuthority,
                 );
 
-                const { bump, vaaHash, status, info } = auctionDataBefore;
+                const { bump, vaaHash, vaaTimestamp, status, info } = auctionDataBefore;
                 const {
                     configId,
                     custodyTokenBump,
                     vaaSequence,
-                    vaaTimestamp,
                     bestOfferToken: prevBestOfferToken,
                     initialOfferToken,
                     startSlot,
@@ -1912,11 +1911,10 @@ describe("Matching Engine", function () {
 
                 const auctionDataAfter = await engine.fetchAuction({ address: auction });
                 expect(auctionDataAfter).to.eql(
-                    new Auction(bump, vaaHash, status, {
+                    new Auction(bump, vaaHash, vaaTimestamp, status, {
                         configId,
                         custodyTokenBump,
                         vaaSequence,
-                        vaaTimestamp,
                         sourceChain,
                         bestOfferToken,
                         initialOfferToken,
@@ -2561,7 +2559,7 @@ describe("Matching Engine", function () {
                     executorToken: executorTokenBefore,
                 } = balancesBefore;
 
-                const { bump, vaaHash, info } = auctionDataBefore;
+                const { bump, vaaHash, vaaTimestamp, info } = auctionDataBefore;
 
                 const auctionDataAfter = await engine.fetchAuction({ address: auction });
 
@@ -2600,6 +2598,7 @@ describe("Matching Engine", function () {
                         new Auction(
                             bump,
                             vaaHash,
+                            vaaTimestamp,
                             {
                                 completed: {
                                     slot: bigintToU64BN(BigInt(txDetails.slot)),
@@ -2644,6 +2643,7 @@ describe("Matching Engine", function () {
                         new Auction(
                             bump,
                             vaaHash,
+                            vaaTimestamp,
                             {
                                 completed: {
                                     slot: bigintToU64BN(BigInt(txDetails.slot)),
@@ -3052,6 +3052,7 @@ describe("Matching Engine", function () {
                         new Auction(
                             bump,
                             Array.from(fastVaaHash),
+                            fast.vaaAccount.timestamp(),
                             {
                                 settled: {
                                     baseFee: bigintToU64BN(baseFee),
@@ -3230,12 +3231,12 @@ describe("Matching Engine", function () {
             new Auction(
                 bump,
                 Array.from(vaaHash),
+                fastVaaAccount.timestamp(),
                 { active: {} },
                 {
                     configId: auctionConfigId,
                     custodyTokenBump,
                     vaaSequence: bigintToU64BN(fastVaaAccount.emitterInfo().sequence),
-                    vaaTimestamp: fastVaaAccount.timestamp(),
                     sourceChain: ethChain,
                     bestOfferToken: offerToken,
                     initialOfferToken: offerToken,

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -2038,6 +2038,9 @@ describe("Matching Engine", function () {
                     playerOne.publicKey,
                     currentSequence - 1n,
                 );
+                const expectedLamports = await connection
+                    .getAccountInfo(cctpMessage)
+                    .then((info) => info!.lamports);
 
                 const messageTransmitter = engine.messageTransmitterProgram();
                 const { message } = await messageTransmitter.fetchMessageSent(cctpMessage);
@@ -2055,10 +2058,10 @@ describe("Matching Engine", function () {
 
                 const balanceBefore = await connection.getBalance(playerOne.publicKey);
 
-                await expectIxOk(connection, [ix], [playerOne]);
+                await expectIxOk(connection, [ix], [payer, playerOne]);
 
                 const balanceAfter = await connection.getBalance(playerOne.publicKey);
-                expect(balanceAfter - balanceBefore).equals(2918200);
+                expect(balanceAfter - balanceBefore).equals(expectedLamports);
             });
 
             it("Cannot Improve Offer After Execute Order", async function () {

--- a/solana/ts/tests/02__tokenRouter.ts
+++ b/solana/ts/tests/02__tokenRouter.ts
@@ -12,7 +12,7 @@ import {
 import { use as chaiUse, expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { CctpTokenBurnMessage } from "../src/cctp";
-import { LiquidityLayerDeposit, LiquidityLayerMessage } from "../src/common";
+import { LiquidityLayerDeposit, LiquidityLayerMessage, uint64ToBN } from "../src/common";
 import { Custodian, PreparedOrder, TokenRouterProgram, localnet } from "../src/tokenRouter";
 import {
     CircleAttester,
@@ -23,7 +23,6 @@ import {
     OWNER_KEYPAIR,
     PAYER_KEYPAIR,
     USDC_MINT_ADDRESS,
-    bigintToU64BN,
     expectIxErr,
     expectIxOk,
     postLiquidityLayerVaa,
@@ -598,7 +597,7 @@ describe("Token Router", function () {
                             preparedBy: payer.publicKey,
                             orderType: {
                                 market: {
-                                    minAmountOut: bigintToU64BN(minAmountOut),
+                                    minAmountOut: uint64ToBN(minAmountOut),
                                 },
                             },
                             srcToken: payerToken,

--- a/solana/ts/tests/04__interaction.ts
+++ b/solana/ts/tests/04__interaction.ts
@@ -927,7 +927,7 @@ describe("Matching Engine <> Token Router", function () {
                         payer: offerAuthorityOne.publicKey,
                         fastVaa,
                     },
-                    maxFee,
+                    { offerPrice: maxFee },
                 );
                 await expectIxOk(connection, [approveIx, ix], [offerAuthorityOne]);
 

--- a/solana/ts/tests/12__testnetFork.ts
+++ b/solana/ts/tests/12__testnetFork.ts
@@ -6,7 +6,6 @@ import * as tokenRouterSdk from "../src/tokenRouter";
 import { testnet, UpgradeManagerProgram, UpgradeReceipt } from "../src/upgradeManager";
 import { BPF_LOADER_UPGRADEABLE_PROGRAM_ID, programDataAddress } from "../src/utils";
 import {
-    bigintToU64BN,
     expectIxErr,
     expectIxOk,
     expectIxOkDetails,
@@ -18,6 +17,7 @@ import {
 
 // TODO: remove
 import "dotenv/config";
+import { uint64ToBN } from "../src/common";
 
 chaiUse(chaiAsPromised);
 
@@ -161,7 +161,7 @@ describe("Upgrade Manager", function () {
                 new UpgradeReceipt(bump, programDataBump, accounts.owner, {
                     uncommitted: {
                         buffer: matchingEngineBuffer,
-                        slot: bigintToU64BN(BigInt(txDetails!.slot)),
+                        slot: uint64ToBN(txDetails!.slot),
                     },
                 }),
             );
@@ -367,7 +367,7 @@ describe("Upgrade Manager", function () {
                 new UpgradeReceipt(bump, programDataBump, accounts.owner, {
                     uncommitted: {
                         buffer: tokenRouterBuffer,
-                        slot: bigintToU64BN(BigInt(txDetails!.slot)),
+                        slot: uint64ToBN(txDetails!.slot),
                     },
                 }),
             );

--- a/solana/ts/tests/helpers/consts.ts
+++ b/solana/ts/tests/helpers/consts.ts
@@ -52,7 +52,7 @@ export const CHAIN_TO_DOMAIN: Partial<{ [k in ChainName]: number }> = {
 
 export const REGISTERED_TOKEN_ROUTERS: Partial<{ [k in ChainName]: Array<number> }> = {
     ethereum: Array.from(Buffer.alloc(32, "f0", "hex")),
-    avalanche: Array.from(Buffer.alloc(32, "a1", "hex")),
+    avalanche: Array.from(Buffer.alloc(32, "f1", "hex")),
     optimism: Array.from(Buffer.alloc(32, "f2", "hex")),
     arbitrum: Array.from(Buffer.alloc(32, "f3", "hex")),
     base: Array.from(Buffer.alloc(32, "f6", "hex")),


### PR DESCRIPTION
Create an account that allows market participants to close existing Auction accounts by moving data to a historical data account.

Closes #28.

Added some test refactoring, too.