### PR TITLE
solana: remove cctp mint recipient; use set authority

### DIFF
--- a/solana/programs/matching-engine/src/composite/mod.rs
+++ b/solana/programs/matching-engine/src/composite/mod.rs
@@ -401,8 +401,6 @@ pub struct WormholePublishMessage<'info> {
 
 #[derive(Accounts)]
 pub struct CctpDepositForBurn<'info> {
-    pub burn_source: CctpMintRecipientMut<'info>,
-
     /// Circle-supported mint.
     ///
     /// CHECK: Mutable. This token account's mint must be the same as the one found in the CCTP

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
@@ -62,6 +62,7 @@ pub struct ExecuteFastOrderLocal<'info> {
 
 pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<()> {
     let custodian = &ctx.accounts.custodian;
+    let token_program = &ctx.accounts.token_program;
 
     let super::PreparedOrderExecution {
         user_amount: amount,
@@ -71,7 +72,7 @@ pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<(
         execute_order: &mut ctx.accounts.execute_order,
         payer_sequence: &mut ctx.accounts.payer_sequence,
         custodian,
-        token_program: &ctx.accounts.token_program,
+        token_program,
     })?;
 
     let payer = &ctx.accounts.payer;
@@ -94,7 +95,6 @@ pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<(
         ctx.bumps.core_message,
     )?;
 
-    let token_program = &ctx.accounts.token_program;
     let auction_custody_token = &ctx.accounts.execute_order.active_auction.custody_token;
 
     // Transfer funds to the local custody account.

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -1163,16 +1163,6 @@
           "name": "cctp",
           "accounts": [
             {
-              "name": "burnSource",
-              "accounts": [
-                {
-                  "name": "mintRecipient",
-                  "isMut": true,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
               "name": "mint",
               "isMut": true,
               "isSigner": false,
@@ -1922,16 +1912,6 @@
         {
           "name": "cctp",
           "accounts": [
-            {
-              "name": "burnSource",
-              "accounts": [
-                {
-                  "name": "mintRecipient",
-                  "isMut": true,
-                  "isSigner": false
-                }
-              ]
-            },
             {
               "name": "mint",
               "isMut": true,

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -1163,16 +1163,6 @@ export type MatchingEngine = {
           "name": "cctp",
           "accounts": [
             {
-              "name": "burnSource",
-              "accounts": [
-                {
-                  "name": "mintRecipient",
-                  "isMut": true,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
               "name": "mint",
               "isMut": true,
               "isSigner": false,
@@ -1922,16 +1912,6 @@ export type MatchingEngine = {
         {
           "name": "cctp",
           "accounts": [
-            {
-              "name": "burnSource",
-              "accounts": [
-                {
-                  "name": "mintRecipient",
-                  "isMut": true,
-                  "isSigner": false
-                }
-              ]
-            },
             {
               "name": "mint",
               "isMut": true,
@@ -4484,16 +4464,6 @@ export const IDL: MatchingEngine = {
           "name": "cctp",
           "accounts": [
             {
-              "name": "burnSource",
-              "accounts": [
-                {
-                  "name": "mintRecipient",
-                  "isMut": true,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
               "name": "mint",
               "isMut": true,
               "isSigner": false,
@@ -5243,16 +5213,6 @@ export const IDL: MatchingEngine = {
         {
           "name": "cctp",
           "accounts": [
-            {
-              "name": "burnSource",
-              "accounts": [
-                {
-                  "name": "mintRecipient",
-                  "isMut": true,
-                  "isSigner": false
-                }
-              ]
-            },
             {
               "name": "mint",
               "isMut": true,

--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -1615,7 +1615,6 @@ export class MatchingEngineProgram {
                     coreBridgeProgram,
                 },
                 cctp: {
-                    burnSource: this.cctpMintRecipientComposite(),
                     mint: this.mint,
                     tokenMessengerMinterSenderAuthority,
                     messageTransmitterConfig,
@@ -1785,7 +1784,6 @@ export class MatchingEngineProgram {
                     coreBridgeProgram,
                 },
                 cctp: {
-                    burnSource: this.cctpMintRecipientComposite(),
                     mint,
                     tokenMessengerMinterSenderAuthority,
                     messageTransmitterConfig,

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -4391,11 +4391,6 @@ describe("Matching Engine", function () {
             connection,
             feeRecipientToken,
         );
-        const preparedCustodyToken = engine.preparedCustodyTokenAddress(preparedOrderResponse);
-        const { amount: custodyBalanceBefore } = await splToken.getAccount(
-            connection,
-            preparedCustodyToken,
-        );
 
         await expectIxOk(connection, [computeIx, ix], signers);
 
@@ -4409,14 +4404,11 @@ describe("Matching Engine", function () {
         );
         expect(feeBalanceAfter).equals(feeBalanceBefore + baseFee);
 
-        const { amount: custodyBalanceAfter } = await splToken.getAccount(
-            connection,
-            preparedCustodyToken,
-        );
-        expect(custodyBalanceAfter).equals(custodyBalanceBefore - deposit.header.amount);
-
-        const { amount: cctpMintRecipientBalance } = await engine.fetchCctpMintRecipient();
-        expect(cctpMintRecipientBalance).equals(0n);
+        {
+            const preparedCustodyToken = engine.preparedCustodyTokenAddress(preparedOrderResponse);
+            const accInfo = await connection.getAccountInfo(preparedCustodyToken);
+            expect(accInfo).is.null;
+        }
 
         const fastVaaAccount = await VaaAccount.fetch(connection, fastVaa);
         const fastVaaHash = fastVaaAccount.digest();


### PR DESCRIPTION
This also fixes the settle auction none instructions by closing the prepared custody token accounts.