### PR TITLE
solana: add example VAA deduper

### DIFF
--- a/solana/Makefile
+++ b/solana/Makefile
@@ -1,6 +1,12 @@
-out_mainnet=artifacts-mainnet
-out_testnet=artifacts-testnet
-out_localnet=artifacts-localnet
+BUILD_mainnet=artifacts-mainnet
+BUILD_testnet=artifacts-testnet
+BUILD_localnet=artifacts-localnet
+
+SPY_NETWORK_mainnet=/wormhole/mainnet/2
+SPY_BOOTSTRAP_mainnet="/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8999/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8999/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1"
+
+SPY_NETWORK_testnet=/wormhole/testnet/2/1
+SPY_BOOTSTRAP_testnet="/dns4/t-guardian-01.nodes.stable.io/udp/8999/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8999/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK"
 
 .PHONY: all
 all: check
@@ -23,13 +29,13 @@ cargo-test:
 
 .PHONY: build
 build:
-ifdef out_$(NETWORK)
-	mkdir $(out_$(NETWORK)) # do not want to continue if the directory already exists
+ifdef BUILD_$(NETWORK)
+	mkdir $(BUILD_$(NETWORK)) # do not want to continue if the directory already exists
 	anchor build --arch sbf -- --features $(NETWORK)
-	cp target/deploy/*.so $(out_$(NETWORK))/
+	cp target/deploy/*.so $(BUILD_$(NETWORK))/
 endif
 
-$(out_$(NETWORK)): cargo-test
+$(BUILD_$(NETWORK)): cargo-test
 
 .PHONY: test
 test: node_modules
@@ -52,3 +58,16 @@ lint:
 	cargo fmt --check
 	NETWORK=localnet $(MAKE) clippy
 	NETWORK=testnet $(MAKE) clippy
+
+.PHONY: run-spy
+wormhole-spy:
+ifdef SPY_NETWORK_$(NETWORK)
+	docker run \
+		--platform=linux/amd64 \
+		-p 7073:7073 \
+		--entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy \
+		--nodeKey /node.key \
+		--spyRPC "[::]:7073" \
+		--network $(SPY_NETWORK_$(NETWORK)) \
+		--bootstrap $(SPY_BOOTSTRAP_$(NETWORK))
+endif

--- a/solana/package-lock.json
+++ b/solana/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.10.10",
+        "@certusone/wormhole-spydk": "^0.0.1",
         "@coral-xyz/anchor": "^0.29.0",
         "@solana/spl-token": "^0.4.0",
         "@solana/web3.js": "^1.87.6",
@@ -196,6 +197,15 @@
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/@certusone/wormhole-spydk": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-spydk/-/wormhole-spydk-0.0.1.tgz",
+      "integrity": "sha512-iBQoY3UnmGoWHcbn0FypA6hKsANhdHKi03UN0GPoDAeMY12j8ly+7r462TfLl5f4hOJVQd3UZ2qviohEmdicmg==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.4.4",
+        "protobufjs": "^6.11.2"
       }
     },
     "node_modules/@classic-terra/terra.proto": {
@@ -1117,6 +1127,63 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
+      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.10",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.12.tgz",
+      "integrity": "sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@improbable-eng/grpc-web": {
       "version": "0.14.1",
       "license": "Apache-2.0",
@@ -1477,6 +1544,15 @@
       "optional": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@metamask/eth-sig-util": {
@@ -4003,6 +4079,11 @@
       "version": "4.17.21",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.values": {
       "version": "4.3.0",

--- a/solana/package.json
+++ b/solana/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.10.10",
+    "@certusone/wormhole-spydk": "^0.0.1",
     "@coral-xyz/anchor": "^0.29.0",
     "@solana/spl-token": "^0.4.0",
     "@solana/web3.js": "^1.87.6",

--- a/solana/ts/scripts/dedupeVaaExample.ts
+++ b/solana/ts/scripts/dedupeVaaExample.ts
@@ -1,0 +1,38 @@
+import { ChainId, tryHexToNativeString } from "@certusone/wormhole-sdk";
+import { VaaSpy } from "../src/wormhole/spy";
+
+async function main() {
+    console.log("init spy");
+
+    const spy = new VaaSpy({
+        spyHost: "localhost:7073",
+        vaaFilters: [
+            {
+                chain: "pythnet",
+                // nativeAddress: "BwDNn2qvZc6drt8Q4zRE2HHys64ZyPXhWxt51ADtWuc1",
+                nativeAddress: "G9LV2mp9ua1znRAfYwZz5cPiJMAbo1T6mbjdQsDZuMJg",
+            },
+        ],
+        enableCleanup: true,
+        seenThresholdMs: 5_000,
+        intervalMs: 250,
+        maxToRemove: 5,
+    });
+
+    spy.onObservation(({ raw, parsed, chain, nativeAddress }) => {
+        console.log(
+            "observed",
+            parsed.emitterChain,
+            chain,
+            nativeAddress,
+            tryHexToNativeString(
+                parsed.emitterAddress.toString("hex"),
+                parsed.emitterChain as ChainId,
+            ),
+            parsed.sequence,
+        );
+    });
+}
+
+// Do it.
+main();

--- a/solana/ts/src/wormhole/spy.ts
+++ b/solana/ts/src/wormhole/spy.ts
@@ -1,0 +1,117 @@
+import {
+    ChainId,
+    ChainName,
+    ParsedVaa,
+    coalesceChainId,
+    parseVaa,
+    tryNativeToUint8Array,
+} from "@certusone/wormhole-sdk";
+import { createSpyRPCServiceClient, subscribeSignedVAA } from "@certusone/wormhole-spydk";
+
+export type VaaContext = {
+    raw: Buffer;
+    parsed: ParsedVaa;
+    chain?: ChainName;
+    nativeAddress?: string;
+};
+
+export type VaaFilter = {
+    chain: ChainName;
+    nativeAddress: string;
+};
+
+export type SpyRequestOpts = {
+    vaaFilters?: VaaFilter[];
+};
+
+export type CleanupOpts = {
+    seenThresholdMs?: number;
+    intervalMs?: number;
+    maxToRemove?: number;
+};
+
+export class VaaSpy {
+    private _spyHost: string;
+    private _enableCleanup: boolean;
+    private _vaaFilters: VaaFilter[] | null;
+
+    private _seenHashes!: Map<string, Date>;
+
+    constructor(
+        opts: { spyHost?: string; enableCleanup?: boolean } & SpyRequestOpts & CleanupOpts = {},
+    ) {
+        this._spyHost = opts.spyHost ?? "localhost:7073";
+        this._enableCleanup = opts.enableCleanup ?? true;
+        if (opts.enableCleanup) {
+            this._startCleanupProcedure(opts);
+        }
+
+        this._vaaFilters = opts.vaaFilters ?? null;
+    }
+
+    async onObservation(callback: (ctx: VaaContext) => void) {
+        const client = createSpyRPCServiceClient(this._spyHost);
+
+        // Really wish we could use a filter here... but alas.
+        const stream = await subscribeSignedVAA(client, {});
+
+        const vaaFilters = this._vaaFilters;
+
+        const that = this;
+        stream.on("data", ({ vaaBytes: raw }) => {
+            const ctx: VaaContext = { raw, parsed: parseVaa(raw) };
+
+            if (vaaFilters === null) {
+                return that.processUniqueVaa(ctx, callback);
+            }
+
+            // Filter out unwanted VAAs.
+            for (const { chain, nativeAddress } of vaaFilters) {
+                if (
+                    ctx.parsed.emitterChain == coalesceChainId(chain) &&
+                    ctx.parsed.emitterAddress.equals(tryNativeToUint8Array(nativeAddress, chain))
+                ) {
+                    return that.processUniqueVaa({ chain, nativeAddress, ...ctx }, callback);
+                }
+            }
+        });
+    }
+
+    processUniqueVaa(ctx: VaaContext, callback: (ctx: VaaContext) => void): void {
+        if (this._enableCleanup) {
+            const hash = ctx.parsed.hash.toString("base64");
+            if (this._seenHashes.has(hash)) {
+                return;
+            }
+
+            this._seenHashes.set(hash, new Date());
+        }
+
+        return callback(ctx);
+    }
+
+    private _startCleanupProcedure(args: CleanupOpts) {
+        let { seenThresholdMs, intervalMs, maxToRemove } = args;
+        seenThresholdMs ??= 2_000; // 2 seconds
+        intervalMs ??= seenThresholdMs;
+        maxToRemove ??= 69_420; // hehe
+
+        this._seenHashes = new Map<string, Date>();
+        const seenHashes = this._seenHashes;
+
+        setInterval(() => {
+            const now = new Date();
+            let numRemoved = 0;
+            for (const [hash, seenTime] of seenHashes.entries()) {
+                if (numRemoved >= maxToRemove!) {
+                    break;
+                }
+
+                if (now.getTime() - seenTime.getTime() > seenThresholdMs!) {
+                    seenHashes.delete(hash);
+                    ++numRemoved;
+                }
+            }
+        }, intervalMs!);
+    }
+}


### PR DESCRIPTION
Simple de-duping mechanism when listening to the Wormhole gossip network. All this uses is a map, which gets cleaned out based on some simple config parameters (interval for timeout, how many to remove at a time, time criteria for when to remove VAA hashes).

Also add to the Makefile a command to run the spy for testnet or mainnet.