### PR TITLE
solana: require executor == prepared by for penalty

### DIFF
--- a/solana/programs/matching-engine/src/error.rs
+++ b/solana/programs/matching-engine/src/error.rs
@@ -64,6 +64,7 @@ pub enum MatchingEngineError {
     AuctionNotCompleted = 0x41a,
     CarpingNotAllowed = 0x41e,
     AuctionNotSettled = 0x420,
+    ExecutorNotPreparedBy = 0x422,
 
     CannotCloseAuctionYet = 0x500,
     AuctionHistoryNotFull = 0x502,

--- a/solana/programs/matching-engine/src/processor/auction/settle/complete.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/complete.rs
@@ -119,6 +119,17 @@ fn handle_settle_auction_complete(
             )
         }
         _ => {
+            // If there is a penalty, we want to return the lamports back to the person who paid to
+            // create the prepared order response and custody token accounts.
+            //
+            // The executor's intention here would be to collect the base fee to cover the cost to
+            // post the finalized VAA.
+            require_keys_eq!(
+                executor_token.owner,
+                prepared_order_response.prepared_by,
+                MatchingEngineError::ExecutorNotPreparedBy
+            );
+
             if executor_token.key() != best_offer_token.key() {
                 // Because the auction participant was penalized for executing the order late, he
                 // will be deducted the base fee. This base fee will be sent to the executor token

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -3375,6 +3375,10 @@
       "name": "AuctionNotSettled"
     },
     {
+      "code": 7058,
+      "name": "ExecutorNotPreparedBy"
+    },
+    {
       "code": 7280,
       "name": "CannotCloseAuctionYet"
     },

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -3375,6 +3375,10 @@ export type MatchingEngine = {
       "name": "AuctionNotSettled"
     },
     {
+      "code": 7058,
+      "name": "ExecutorNotPreparedBy"
+    },
+    {
       "code": 7280,
       "name": "CannotCloseAuctionYet"
     },
@@ -6764,6 +6768,10 @@ export const IDL: MatchingEngine = {
     {
       "code": 7056,
       "name": "AuctionNotSettled"
+    },
+    {
+      "code": 7058,
+      "name": "ExecutorNotPreparedBy"
     },
     {
       "code": 7280,

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -3141,6 +3141,7 @@ describe("Matching Engine", function () {
                             executor: payer.publicKey,
                         },
                         {
+                            prepareSigners: [payer],
                             executeOrder: false,
                             errorMsg: "Error Code: AuctionNotCompleted",
                         },
@@ -3153,6 +3154,7 @@ describe("Matching Engine", function () {
                             executor: payer.publicKey,
                         },
                         {
+                            prepareSigners: [payer],
                             executeWithinGracePeriod: true,
                             errorMsg: "Error Code: ExecutorTokenMismatch",
                         },

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -3165,6 +3165,7 @@ describe("Matching Engine", function () {
                             executor: playerOne.publicKey,
                         },
                         {
+                            prepareSigners: [playerOne],
                             executeWithinGracePeriod: true,
                         },
                     );
@@ -3176,8 +3177,22 @@ describe("Matching Engine", function () {
                             executor: playerOne.publicKey,
                         },
                         {
+                            prepareSigners: [playerOne],
                             executeWithinGracePeriod: true,
                             prepareAfterExecuteOrder: false,
+                        },
+                    );
+                });
+
+                it("Cannot Settle Completed with Penalty (Executor != Prepared By)", async function () {
+                    await settleAuctionCompleteForTest(
+                        {
+                            executor: playerOne.publicKey,
+                        },
+                        {
+                            executeWithinGracePeriod: false,
+                            executorIsPreparer: false,
+                            errorMsg: "Error Code: ExecutorNotPreparedBy",
                         },
                     );
                 });
@@ -3188,6 +3203,7 @@ describe("Matching Engine", function () {
                             executor: playerOne.publicKey,
                         },
                         {
+                            prepareSigners: [playerOne],
                             executeWithinGracePeriod: false,
                         },
                     );
@@ -3199,6 +3215,7 @@ describe("Matching Engine", function () {
                             executor: playerTwo.publicKey,
                         },
                         {
+                            prepareSigners: [playerTwo],
                             executeWithinGracePeriod: false,
                         },
                     );
@@ -3684,7 +3701,7 @@ describe("Matching Engine", function () {
                         if (settlementType == "complete") {
                             const result = await settleAuctionCompleteForTest(
                                 { executor: playerOne.publicKey },
-                                { vaaTimestamp },
+                                { vaaTimestamp, prepareSigners: [playerOne] },
                             );
                             return result!.auction;
                         } else if (settlementType == "none") {
@@ -4121,15 +4138,21 @@ describe("Matching Engine", function () {
                     const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
                         units: 300_000,
                     });
+
+                    const { value: lookupTableAccount } = await connection.getAddressLookupTable(
+                        lookupTableAddress,
+                    );
                     const ix = await engine.executeFastOrderCctpIx({
-                        payer: accounts.payer,
+                        payer: payer.publicKey,
                         fastVaa,
                         auction,
                         auctionConfig,
                         bestOfferToken,
                         initialOfferToken,
                     });
-                    await expectIxOk(connection, [computeIx, ix], [payer]);
+                    await expectIxOk(connection, [computeIx, ix], [payer], {
+                        addressLookupTableAccounts: [lookupTableAccount!],
+                    });
                 }
             }
         };
@@ -4234,7 +4257,7 @@ describe("Matching Engine", function () {
 
     async function settleAuctionCompleteForTest(
         accounts: {
-            executor: PublicKey;
+            executor?: PublicKey;
             preparedOrderResponse?: PublicKey;
             auction?: PublicKey;
             bestOfferToken?: PublicKey;
@@ -4242,12 +4265,17 @@ describe("Matching Engine", function () {
         opts: ForTestOpts &
             ObserveCctpOrderVaasOpts &
             PrepareOrderResponseForTestOptionalOpts & {
+                executorIsPreparer?: boolean;
+                prepareSigners?: Signer[];
                 preparedInSameTransaction?: boolean;
             } = {},
     ): Promise<void | { auction: PublicKey }> {
         let [{ signers, errorMsg }, excludedForTestOpts] = setDefaultForTestOpts(opts);
-        let { preparedInSameTransaction } = excludedForTestOpts;
+        let { executorIsPreparer, prepareSigners, preparedInSameTransaction } = excludedForTestOpts;
+        executorIsPreparer ??= true;
+        prepareSigners ??= [playerOne];
         preparedInSameTransaction ??= false; // TODO: do something with this
+
         if (preparedInSameTransaction) {
             throw new Error("preparedInSameTransaction not implemented");
         }
@@ -4262,16 +4290,27 @@ describe("Matching Engine", function () {
             } else {
                 const result = await prepareOrderResponseCctpForTest(
                     {
-                        payer: payer.publicKey,
+                        payer: executorIsPreparer
+                            ? accounts.executor ?? playerOne.publicKey
+                            : payer.publicKey,
                     },
-                    excludedForTestOpts,
+                    {
+                        signers: executorIsPreparer ? prepareSigners : [payer],
+                        ...excludedForTestOpts,
+                    },
                 );
                 expect(typeof result == "object" && "preparedOrderResponse" in result).is.true;
                 return result!;
             }
         })();
 
-        const ix = await engine.settleAuctionCompleteIx({ ...accounts, preparedOrderResponse });
+        const executor = accounts.executor ?? playerOne.publicKey;
+
+        const ix = await engine.settleAuctionCompleteIx({
+            ...accounts,
+            executor,
+            preparedOrderResponse,
+        });
 
         if (errorMsg !== null) {
             return expectIxErr(connection, [ix], signers, errorMsg);
@@ -4291,25 +4330,24 @@ describe("Matching Engine", function () {
         });
 
         const { bestOfferToken } = info!;
-        const executorToken = splToken.getAssociatedTokenAddressSync(
-            USDC_MINT_ADDRESS,
-            accounts.executor,
-        );
+        const executorToken = splToken.getAssociatedTokenAddressSync(USDC_MINT_ADDRESS, executor);
         const { owner: bestOfferAuthority, amount: bestOfferTokenBalanceBefore } =
             await splToken.getAccount(connection, bestOfferToken);
 
         let executorTokenBalanceBefore: bigint | null = null;
-        if (
-            (opts.executeWithinGracePeriod ?? true) ||
-            accounts.executor.equals(bestOfferAuthority)
-        ) {
+        if ((opts.executeWithinGracePeriod ?? true) || executor.equals(bestOfferAuthority)) {
             expect(accounts.executor).to.eql(bestOfferAuthority);
         } else {
+            const { preparedBy } = await engine.fetchPreparedOrderResponse({
+                address: preparedOrderResponse,
+            });
+            expect(accounts.executor).to.eql(preparedBy);
+
             const { amount } = await splToken.getAccount(connection, executorToken);
             executorTokenBalanceBefore = amount;
         }
 
-        const authorityLamportsBefore = await connection.getBalance(accounts.executor);
+        const authorityLamportsBefore = await connection.getBalance(executor);
 
         const preparedCustodyToken = engine.preparedCustodyTokenAddress(preparedOrderResponse);
         const { amount: preparedCustodyBalanceBefore } = await splToken.getAccount(
@@ -4359,7 +4397,7 @@ describe("Matching Engine", function () {
             expect(executorTokenBalanceAfter).equals(executorTokenBalanceBefore + baseFee);
         }
 
-        const authorityLamportsAfter = await connection.getBalance(accounts.executor);
+        const authorityLamportsAfter = await connection.getBalance(executor);
         expect(authorityLamportsAfter).equals(
             authorityLamportsBefore + preparedOrderLamports + preparedCustodyLamports,
         );


### PR DESCRIPTION
Require that the executor is the one who prepared the order response and custody token accounts.

Fixing the test made using the test method a bit uglier. We should clean this up in another PR.