### PR TITLE
solana: fix order executed event

### DIFF
--- a/solana/programs/matching-engine/src/events/order_executed.rs
+++ b/solana/programs/matching-engine/src/events/order_executed.rs
@@ -6,5 +6,7 @@ use anchor_lang::prelude::*;
 pub struct OrderExecuted {
     pub auction: Pubkey,
     pub vaa: Pubkey,
+    pub source_chain: u16,
     pub target_protocol: MessageProtocol,
+    pub penalized: bool,
 }

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -3156,10 +3156,20 @@
           "index": false
         },
         {
+          "name": "sourceChain",
+          "type": "u16",
+          "index": false
+        },
+        {
           "name": "targetProtocol",
           "type": {
             "defined": "MessageProtocol"
           },
+          "index": false
+        },
+        {
+          "name": "penalized",
+          "type": "bool",
           "index": false
         }
       ]

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -3156,10 +3156,20 @@ export type MatchingEngine = {
           "index": false
         },
         {
+          "name": "sourceChain",
+          "type": "u16",
+          "index": false
+        },
+        {
           "name": "targetProtocol",
           "type": {
             "defined": "MessageProtocol"
           },
+          "index": false
+        },
+        {
+          "name": "penalized",
+          "type": "bool",
           "index": false
         }
       ]
@@ -6559,10 +6569,20 @@ export const IDL: MatchingEngine = {
           "index": false
         },
         {
+          "name": "sourceChain",
+          "type": "u16",
+          "index": false
+        },
+        {
           "name": "targetProtocol",
           "type": {
             "defined": "MessageProtocol"
           },
+          "index": false
+        },
+        {
+          "name": "penalized",
+          "type": "bool",
           "index": false
         }
       ]


### PR DESCRIPTION
Adding source chain and penalized boolean.

Penalized boolean can be useful for those folks looking to collect the base fee in settling auctions where the winning participant was penalized for executing the order after the grace period.