### PR TITLE
solana: handle non-existent token accounts

### DIFF
--- a/solana/programs/matching-engine/src/error.rs
+++ b/solana/programs/matching-engine/src/error.rs
@@ -67,6 +67,7 @@ pub enum MatchingEngineError {
     CarpingNotAllowed = 0x41e,
     AuctionNotSettled = 0x420,
     ExecutorNotPreparedBy = 0x422,
+    InvalidOfferToken = 0x424,
 
     CannotCloseAuctionYet = 0x500,
     AuctionHistoryNotFull = 0x502,

--- a/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
@@ -63,7 +63,13 @@ pub fn improve_offer(ctx: Context<ImproveOffer>, offer_price: u64) -> Result<()>
         if offer_token.key() != best_offer_token.key() {
             // These operations will seem silly, but we do this as a safety measure to ensure that
             // nothing terrible happened with the auction's custody account.
-            let total_deposit = ctx.accounts.active_auction.custody_token.amount;
+            let total_deposit = ctx
+                .accounts
+                .active_auction
+                .info
+                .as_ref()
+                .unwrap()
+                .total_deposit();
 
             // If the best offer token happens to be closed, we will just keep the funds in the
             // auction custody account. The executor token account will collect these funds when the

--- a/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
@@ -40,6 +40,11 @@ pub struct ImproveOffer<'info> {
     )]
     active_auction: ActiveAuction<'info>,
 
+    #[account(
+        constraint = {
+            offer_token.key() != active_auction.custody_token.key()
+        } @ MatchingEngineError::InvalidOfferToken,
+    )]
     offer_token: Account<'info, token::TokenAccount>,
 
     token_program: Program<'info, token::Token>,

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -3365,6 +3365,10 @@
       "name": "ExecutorNotPreparedBy"
     },
     {
+      "code": 7060,
+      "name": "InvalidOfferToken"
+    },
+    {
       "code": 7280,
       "name": "CannotCloseAuctionYet"
     },

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -3365,6 +3365,10 @@ export type MatchingEngine = {
       "name": "ExecutorNotPreparedBy"
     },
     {
+      "code": 7060,
+      "name": "InvalidOfferToken"
+    },
+    {
       "code": 7280,
       "name": "CannotCloseAuctionYet"
     },
@@ -6744,6 +6748,10 @@ export const IDL: MatchingEngine = {
     {
       "code": 7058,
       "name": "ExecutorNotPreparedBy"
+    },
+    {
+      "code": 7060,
+      "name": "InvalidOfferToken"
     },
     {
       "code": 7280,


### PR DESCRIPTION
In case token accounts are closed during the auction process, handle these cases by sending funds to the executor token when orders are executed.