### PR TITLE
solana: fix prepare order response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+.private
+.vscode

--- a/solana/.gitignore
+++ b/solana/.gitignore
@@ -1,8 +1,5 @@
-.DS_Store
 .anchor
 .env
-.private
-.vscode
 **/*.rs.bk
 /artifacts-*
 /cfg/**/*.json

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 name = "liquidity-layer-messages"
 version = "0.0.0"
 dependencies = [
- "wormhole-io",
+ "wormhole-io 0.2.0-alpha.3",
  "wormhole-raw-vaas",
 ]
 
@@ -2345,7 +2345,7 @@ version = "0.0.0"
 dependencies = [
  "anchor-lang",
  "token-router",
- "wormhole-io",
+ "wormhole-io 0.2.0-alpha.3",
 ]
 
 [[package]]
@@ -2626,7 +2626,7 @@ dependencies = [
  "cfg-if",
  "hex",
  "ruint",
- "wormhole-io",
+ "wormhole-io 0.1.3",
  "wormhole-raw-vaas",
  "wormhole-solana-consts",
  "wormhole-solana-vaas",
@@ -2637,6 +2637,12 @@ name = "wormhole-io"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021a14ea7bcef9517ed9f81d4466c4a663dd90e726c5724707a976fa83ad8f3"
+
+[[package]]
+name = "wormhole-io"
+version = "0.2.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad2d95271f793ef236e8f73a58f332b8d439584eeb0dff9d6cd8101c8ea4739"
 
 [[package]]
 name = "wormhole-raw-vaas"

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.2.0-alpha.11"
 features = ["anchor"]
 
 [workspace.dependencies]
-wormhole-io = "0.1.2"
+wormhole-io = "0.2.0-alpha.3"
 wormhole-solana-consts = "0.2.0-alpha.11"
 anchor-lang = "0.29.0"
 anchor-spl = "0.29.0"

--- a/solana/modules/token-router-sdk/src/accounts/prepared_fill.rs
+++ b/solana/modules/token-router-sdk/src/accounts/prepared_fill.rs
@@ -5,23 +5,35 @@ use token_router::state::PreparedFillInfo;
 use wormhole_io::{Readable, TypePrefixedPayload};
 
 #[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone)]
-pub struct PreparedFill<P: TypePrefixedPayload> {
+pub struct PreparedFill<const N: usize, P>
+where
+    P: TypePrefixedPayload<N>,
+{
     pub info: PreparedFillInfo,
     pub message_size: u32,
     pub redeemer_message: P,
 }
 
-impl<P: TypePrefixedPayload> Owner for PreparedFill<P> {
+impl<const N: usize, P> Owner for PreparedFill<N, P>
+where
+    P: TypePrefixedPayload<N>,
+{
     fn owner() -> Pubkey {
         token_router::ID
     }
 }
 
-impl<P: TypePrefixedPayload> Discriminator for PreparedFill<P> {
+impl<const N: usize, P> Discriminator for PreparedFill<N, P>
+where
+    P: TypePrefixedPayload<N>,
+{
     const DISCRIMINATOR: [u8; 8] = token_router::state::PreparedFill::DISCRIMINATOR;
 }
 
-impl<P: TypePrefixedPayload> AccountSerialize for PreparedFill<P> {
+impl<const N: usize, P> AccountSerialize for PreparedFill<N, P>
+where
+    P: TypePrefixedPayload<N>,
+{
     fn try_serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> Result<()> {
         Self::DISCRIMINATOR.serialize(writer)?;
         self.info.serialize(writer)?;
@@ -31,7 +43,10 @@ impl<P: TypePrefixedPayload> AccountSerialize for PreparedFill<P> {
     }
 }
 
-impl<P: TypePrefixedPayload> AccountDeserialize for PreparedFill<P> {
+impl<const N: usize, P> AccountDeserialize for PreparedFill<N, P>
+where
+    P: TypePrefixedPayload<N>,
+{
     fn try_deserialize(buf: &mut &[u8]) -> Result<Self> {
         let disc_len = Self::DISCRIMINATOR.len();
         if buf.len() < disc_len {
@@ -53,7 +68,10 @@ impl<P: TypePrefixedPayload> AccountDeserialize for PreparedFill<P> {
     }
 }
 
-impl<P: TypePrefixedPayload> Deref for PreparedFill<P> {
+impl<const N: usize, P> Deref for PreparedFill<N, P>
+where
+    P: TypePrefixedPayload<N>,
+{
     type Target = PreparedFillInfo;
 
     fn deref(&self) -> &Self::Target {

--- a/solana/programs/matching-engine/src/error.rs
+++ b/solana/programs/matching-engine/src/error.rs
@@ -17,6 +17,7 @@ pub enum MatchingEngineError {
     InvalidDepositPayloadId = 0x48,
     NotFastMarketOrder = 0x4a,
     VaaMismatch = 0x4c,
+    RedeemerMessageTooLarge = 0x4e,
 
     InvalidSourceRouter = 0x60,
     InvalidTargetRouter = 0x62,

--- a/solana/programs/matching-engine/src/processor/admin/router_endpoint/disable.rs
+++ b/solana/programs/matching-engine/src/processor/admin/router_endpoint/disable.rs
@@ -9,7 +9,7 @@ pub struct DisableRouterEndpoint<'info> {
 }
 
 pub fn disable_router_endpoint(ctx: Context<DisableRouterEndpoint>) -> Result<()> {
-    let endpoint = &mut ctx.accounts.router_endpoint;
+    let endpoint = &mut ctx.accounts.router_endpoint.info;
     endpoint.protocol = MessageProtocol::None;
     endpoint.address = Default::default();
     endpoint.mint_recipient = Default::default();

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
@@ -178,7 +178,7 @@ pub fn handle_execute_fast_order_cctp(
             amount,
             mint_recipient: ctx.accounts.to_router_endpoint.mint_recipient,
             wormhole_message_nonce: common::WORMHOLE_MESSAGE_NONCE,
-            payload: fill.to_vec_payload(),
+            payload: fill.to_vec(),
         },
     )?;
 

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 use anchor_lang::prelude::*;
 use anchor_spl::token;
-use common::messages::{raw::LiquidityLayerMessage, Fill};
+use common::messages::{
+    raw::{LiquidityLayerMessage, MessageToVec},
+    Fill,
+};
 
 struct PrepareFastExecution<'ctx, 'info> {
     execute_order: &'ctx mut ExecuteOrder<'info>,
@@ -227,7 +230,10 @@ fn prepare_order_execution(accounts: PrepareFastExecution) -> Result<PreparedOrd
             source_chain: vaa.emitter_chain(),
             order_sender: order.sender(),
             redeemer: order.redeemer(),
-            redeemer_message: <&[u8]>::from(order.redeemer_message()).to_vec().into(),
+            redeemer_message: order
+                .message_to_vec()
+                .try_into()
+                .map_err(|_| MatchingEngineError::RedeemerMessageTooLarge)?,
         },
     })
 }

--- a/solana/programs/matching-engine/src/processor/auction/prepare_settlement/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/prepare_settlement/cctp.rs
@@ -1,12 +1,12 @@
 use crate::{
     composite::*,
     error::MatchingEngineError,
-    state::{Custodian, PreparedOrderResponse},
+    state::{Custodian, PreparedOrderResponse, PreparedOrderResponseInfo},
 };
 use anchor_lang::prelude::*;
 use anchor_spl::token;
 use common::{
-    messages::raw::{LiquidityLayerDepositMessage, LiquidityLayerMessage},
+    messages::raw::{LiquidityLayerDepositMessage, LiquidityLayerMessage, MessageToVec},
     wormhole_cctp_solana::{self, cctp::message_transmitter_program},
 };
 
@@ -64,7 +64,17 @@ pub struct PrepareOrderResponseCctp<'info> {
     #[account(
         init_if_needed,
         payer = payer,
-        space = 8 + PreparedOrderResponse::INIT_SPACE,
+        space = PreparedOrderResponse::compute_size({
+            let fast_vaa = fast_order_path.fast_vaa.load_unchecked();
+            let message = LiquidityLayerMessage::try_from(fast_vaa.payload())
+                .unwrap();
+            let order = message
+                .fast_market_order()
+                .ok_or(MatchingEngineError::InvalidPayloadId)?;
+
+            // This is safe to unwrap because the length will not exceed u32.
+            order.redeemer_message_len().try_into().unwrap()
+        }),
         seeds = [
             PreparedOrderResponse::SEED_PREFIX,
             fast_order_path.fast_vaa.load_unchecked().digest().as_ref()
@@ -177,25 +187,19 @@ fn handle_prepare_order_response_cctp(
         },
     )?;
 
-    // This should be infallible because:
-    // 1. We know that the fast VAA was used to start this auction (using its hash for the
-    //    auction data PDA).
-    // 2. The finalized VAA's sequence is one greater than the fast VAA's sequence.
-    //
-    // However, we will still process results in case Token Router implementation renders any of
-    // these assumptions invalid.
     let finalized_msg = LiquidityLayerMessage::try_from(finalized_vaa.payload()).unwrap();
     let deposit = finalized_msg.to_deposit_unchecked();
-    let base_fee = LiquidityLayerDepositMessage::try_from(deposit.payload())
-        .unwrap()
-        .to_slow_order_response_unchecked()
-        .base_fee();
+    let message = LiquidityLayerDepositMessage::try_from(deposit.payload()).unwrap();
+    let order_response = message
+        .slow_order_response()
+        .ok_or(MatchingEngineError::InvalidPayloadId)?;
 
     let fast_vaa = ctx.accounts.fast_order_path.fast_vaa.load_unchecked();
-    let amount = LiquidityLayerMessage::try_from(fast_vaa.payload())
+    let order = LiquidityLayerMessage::try_from(fast_vaa.payload())
         .unwrap()
-        .to_fast_market_order_unchecked()
-        .amount_in();
+        .to_fast_market_order_unchecked();
+
+    let amount_in = order.amount_in();
 
     // Write to the prepared slow order account, which will be closed by one of the following
     // instructions:
@@ -206,10 +210,19 @@ fn handle_prepare_order_response_cctp(
         .prepared_order_response
         .set_inner(PreparedOrderResponse {
             bump: ctx.bumps.prepared_order_response,
-            fast_vaa_hash: fast_vaa.digest().0,
-            prepared_by: ctx.accounts.payer.key(),
-            source_chain: finalized_vaa.emitter_chain(),
-            base_fee,
+            info: PreparedOrderResponseInfo {
+                fast_vaa_hash: fast_vaa.digest().0,
+                prepared_by: ctx.accounts.payer.key(),
+                source_chain: finalized_vaa.emitter_chain(),
+                base_fee: order_response.base_fee(),
+                fast_vaa_timestamp: fast_vaa.timestamp(),
+                amount_in,
+                sender: order.sender(),
+                redeemer: order.redeemer(),
+                init_auction_fee: order.init_auction_fee(),
+            },
+            to_endpoint: ctx.accounts.fast_order_path.to_endpoint.info,
+            redeemer_message: order.message_to_vec(),
         });
 
     // Finally transfer minted via CCTP to prepared custody token.
@@ -223,6 +236,6 @@ fn handle_prepare_order_response_cctp(
             },
             &[Custodian::SIGNER_SEEDS],
         ),
-        amount,
+        amount_in,
     )
 }

--- a/solana/programs/matching-engine/src/processor/auction/settle/none/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/none/mod.rs
@@ -27,8 +27,8 @@ struct SettledNone {
     fill: Fill,
 }
 
-fn settle_none_and_prepare_fill<'ctx, 'info>(
-    accounts: SettleNoneAndPrepareFill<'ctx, 'info>,
+fn settle_none_and_prepare_fill(
+    accounts: SettleNoneAndPrepareFill<'_, '_>,
     auction_bump_seed: u8,
 ) -> Result<SettledNone> {
     let SettleNoneAndPrepareFill {

--- a/solana/programs/matching-engine/src/state/prepared_order_response.rs
+++ b/solana/programs/matching-engine/src/state/prepared_order_response.rs
@@ -1,17 +1,50 @@
 use anchor_lang::prelude::*;
 
-#[account]
-#[derive(Debug, InitSpace)]
-pub struct PreparedOrderResponse {
-    pub bump: u8,
+use super::EndpointInfo;
+
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct PreparedOrderResponseInfo {
     pub fast_vaa_hash: [u8; 32],
 
     pub prepared_by: Pubkey,
 
+    pub fast_vaa_timestamp: u32,
     pub source_chain: u16,
     pub base_fee: u64,
+    pub init_auction_fee: u64,
+    pub sender: [u8; 32],
+    pub redeemer: [u8; 32],
+    pub amount_in: u64,
+}
+
+#[account]
+#[derive(Debug)]
+pub struct PreparedOrderResponse {
+    pub bump: u8,
+    pub info: PreparedOrderResponseInfo,
+    pub to_endpoint: EndpointInfo,
+    pub redeemer_message: Vec<u8>,
+}
+
+impl std::ops::Deref for PreparedOrderResponse {
+    type Target = PreparedOrderResponseInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
 }
 
 impl PreparedOrderResponse {
     pub const SEED_PREFIX: &'static [u8] = b"order-response";
+
+    pub fn compute_size(redeemer_message_len: usize) -> usize {
+        const FIXED: usize = 8 // DISCRIMINATOR
+            + 1 // bump
+            + PreparedOrderResponseInfo::INIT_SPACE
+            + EndpointInfo::INIT_SPACE
+            + 4 // redeemer_message length
+            ;
+
+        redeemer_message_len.saturating_add(FIXED)
+    }
 }

--- a/solana/programs/matching-engine/src/state/router_endpoint.rs
+++ b/solana/programs/matching-engine/src/state/router_endpoint.rs
@@ -26,12 +26,8 @@ impl std::fmt::Display for MessageProtocol {
     }
 }
 
-#[account]
-#[derive(Debug, InitSpace)]
-/// Foreign emitter account data.
-pub struct RouterEndpoint {
-    pub bump: u8,
-
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone, Copy, InitSpace)]
+pub struct EndpointInfo {
     /// Emitter chain. Cannot equal `1` (Solana's Chain ID).
     pub chain: u16,
 
@@ -44,6 +40,22 @@ pub struct RouterEndpoint {
 
     /// Specific message protocol used to move assets.
     pub protocol: MessageProtocol,
+}
+
+#[account]
+#[derive(Debug, InitSpace)]
+/// Foreign emitter account data.
+pub struct RouterEndpoint {
+    pub bump: u8,
+    pub info: EndpointInfo,
+}
+
+impl std::ops::Deref for RouterEndpoint {
+    type Target = EndpointInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
 }
 
 impl RouterEndpoint {

--- a/solana/programs/matching-engine/src/utils/admin.rs
+++ b/solana/programs/matching-engine/src/utils/admin.rs
@@ -48,10 +48,12 @@ pub(crate) fn handle_add_cctp_router_endpoint(
 
     router_endpoint.set_inner(RouterEndpoint {
         bump,
-        chain,
-        address,
-        mint_recipient,
-        protocol: MessageProtocol::Cctp { domain },
+        info: EndpointInfo {
+            chain,
+            address,
+            mint_recipient,
+            protocol: MessageProtocol::Cctp { domain },
+        },
     });
 
     // Done.
@@ -69,11 +71,13 @@ pub(crate) fn handle_add_local_router_endpoint(
 
     router_endpoint.set_inner(RouterEndpoint {
         bump,
-        chain: SOLANA_CHAIN,
-        address: token_router_emitter.key().to_bytes(),
-        mint_recipient: token_router_custody_token.key().to_bytes(),
-        protocol: crate::state::MessageProtocol::Local {
-            program_id: token_router_program.key(),
+        info: EndpointInfo {
+            chain: SOLANA_CHAIN,
+            address: token_router_emitter.key().to_bytes(),
+            mint_recipient: token_router_custody_token.key().to_bytes(),
+            protocol: crate::state::MessageProtocol::Local {
+                program_id: token_router_program.key(),
+            },
         },
     });
 

--- a/solana/programs/matching-engine/src/utils/wormhole.rs
+++ b/solana/programs/matching-engine/src/utils/wormhole.rs
@@ -20,7 +20,7 @@ pub fn post_matching_engine_message<M>(
     core_message_bump_seed: u8,
 ) -> Result<()>
 where
-    M: TypePrefixedPayload,
+    M: TypePrefixedPayload<1>,
 {
     let PostMatchingEngineMessage {
         wormhole,
@@ -63,7 +63,7 @@ where
         ),
         core_bridge_program::cpi::PostMessageArgs {
             nonce: common::WORMHOLE_MESSAGE_NONCE,
-            payload: message.to_vec_payload(),
+            payload: message.to_vec(),
             commitment: core_bridge_program::Commitment::Finalized,
         },
     )

--- a/solana/programs/token-router/src/error.rs
+++ b/solana/programs/token-router/src/error.rs
@@ -9,6 +9,7 @@ pub enum TokenRouterError {
 
     InvalidDepositMessage = 0x44,
     InvalidPayloadId = 0x46,
+    RedeemerMessageTooLarge = 0x4e,
 
     InvalidSourceRouter = 0x60,
     InvalidTargetRouter = 0x62,

--- a/solana/programs/token-router/src/processor/market_order/place_cctp.rs
+++ b/solana/programs/token-router/src/processor/market_order/place_cctp.rs
@@ -269,9 +269,11 @@ fn handle_place_market_order_cctp(
                 source_chain: SOLANA_CHAIN,
                 order_sender: order_info.order_sender.to_bytes(),
                 redeemer: order_info.redeemer,
-                redeemer_message: redeemer_message.into(),
+                redeemer_message: redeemer_message
+                    .try_into()
+                    .map_err(|_| TokenRouterError::RedeemerMessageTooLarge)?,
             }
-            .to_vec_payload(),
+            .to_vec(),
         },
     )?;
 

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -1852,46 +1852,6 @@
           ]
         },
         {
-          "name": "fastOrderPath",
-          "accounts": [
-            {
-              "name": "fastVaa",
-              "accounts": [
-                {
-                  "name": "vaa",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "path",
-              "accounts": [
-                {
-                  "name": "fromEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                },
-                {
-                  "name": "toEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
           "name": "auction",
           "isMut": true,
           "isSigner": false,
@@ -2090,46 +2050,6 @@
               "name": "custodyToken",
               "isMut": true,
               "isSigner": false
-            }
-          ]
-        },
-        {
-          "name": "fastOrderPath",
-          "accounts": [
-            {
-              "name": "fastVaa",
-              "accounts": [
-                {
-                  "name": "vaa",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "path",
-              "accounts": [
-                {
-                  "name": "fromEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                },
-                {
-                  "name": "toEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                }
-              ]
             }
           ]
         },
@@ -2506,25 +2426,20 @@
             "type": "u8"
           },
           {
-            "name": "fastVaaHash",
+            "name": "info",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "defined": "PreparedOrderResponseInfo"
             }
           },
           {
-            "name": "preparedBy",
-            "type": "publicKey"
+            "name": "toEndpoint",
+            "type": {
+              "defined": "EndpointInfo"
+            }
           },
           {
-            "name": "sourceChain",
-            "type": "u16"
-          },
-          {
-            "name": "baseFee",
-            "type": "u64"
+            "name": "redeemerMessage",
+            "type": "bytes"
           }
         ]
       }
@@ -2611,44 +2526,9 @@
             "type": "u8"
           },
           {
-            "name": "chain",
-            "docs": [
-              "Emitter chain. Cannot equal `1` (Solana's Chain ID)."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "address",
-            "docs": [
-              "Emitter address. Cannot be zero address."
-            ],
+            "name": "info",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "mintRecipient",
-            "docs": [
-              "Future-proof field in case another network has token accounts to send assets to instead of",
-              "sending to the address directly."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "protocol",
-            "docs": [
-              "Specific message protocol used to move assets."
-            ],
-            "type": {
-              "defined": "MessageProtocol"
+              "defined": "EndpointInfo"
             }
           }
         ]
@@ -2894,6 +2774,114 @@
               "option": {
                 "defined": "AuctionDestinationAssetInfo"
               }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PreparedOrderResponseInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fastVaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "preparedBy",
+            "type": "publicKey"
+          },
+          {
+            "name": "fastVaaTimestamp",
+            "type": "u32"
+          },
+          {
+            "name": "sourceChain",
+            "type": "u16"
+          },
+          {
+            "name": "baseFee",
+            "type": "u64"
+          },
+          {
+            "name": "initAuctionFee",
+            "type": "u64"
+          },
+          {
+            "name": "sender",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "redeemer",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "amountIn",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EndpointInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain",
+            "docs": [
+              "Emitter chain. Cannot equal `1` (Solana's Chain ID)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "address",
+            "docs": [
+              "Emitter address. Cannot be zero address."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "mintRecipient",
+            "docs": [
+              "Future-proof field in case another network has token accounts to send assets to instead of",
+              "sending to the address directly."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "protocol",
+            "docs": [
+              "Specific message protocol used to move assets."
+            ],
+            "type": {
+              "defined": "MessageProtocol"
             }
           }
         ]
@@ -3237,6 +3225,10 @@
     {
       "code": 6076,
       "name": "VaaMismatch"
+    },
+    {
+      "code": 6078,
+      "name": "RedeemerMessageTooLarge"
     },
     {
       "code": 6096,

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -686,8 +686,8 @@
     {
       "name": "closeProposal",
       "docs": [
-        "This instruction is used to close an existing proposal by closing the propsal account. This",
-        "instruction can only be called by the `owner`.",
+        "This instruction is used to close an existing proposal by closing the proposal account. This",
+        "instruction can only be called by the `owner` or `owner_assistant`.",
         "# Arguments",
         "",
         "* `ctx` - `CloseProposal` context."
@@ -767,7 +767,7 @@
       "name": "updateFeeRecipient",
       "docs": [
         "This instruction is used to update the `fee_recipient` field in the `Custodian` account. This",
-        "instruction can only be called by the `owner`.",
+        "instruction can only be called by the `owner` or `owner_assistant`.",
         "# Arguments",
         "",
         "* `ctx` - `UpdateFeeRecipient` context."
@@ -1539,12 +1539,42 @@
           ]
         },
         {
-          "name": "fastVaa",
+          "name": "fastOrderPath",
           "accounts": [
             {
-              "name": "vaa",
-              "isMut": false,
-              "isSigner": false
+              "name": "fastVaa",
+              "accounts": [
+                {
+                  "name": "vaa",
+                  "isMut": false,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "path",
+              "accounts": [
+                {
+                  "name": "fromEndpoint",
+                  "accounts": [
+                    {
+                      "name": "endpoint",
+                      "isMut": false,
+                      "isSigner": false
+                    }
+                  ]
+                },
+                {
+                  "name": "toEndpoint",
+                  "accounts": [
+                    {
+                      "name": "endpoint",
+                      "isMut": false,
+                      "isSigner": false
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/solana/target/idl/token_router.json
+++ b/solana/target/idl/token_router.json
@@ -1347,6 +1347,10 @@
       "name": "InvalidPayloadId"
     },
     {
+      "code": 6078,
+      "name": "RedeemerMessageTooLarge"
+    },
+    {
       "code": 6096,
       "name": "InvalidSourceRouter"
     },

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -686,8 +686,8 @@ export type MatchingEngine = {
     {
       "name": "closeProposal",
       "docs": [
-        "This instruction is used to close an existing proposal by closing the propsal account. This",
-        "instruction can only be called by the `owner`.",
+        "This instruction is used to close an existing proposal by closing the proposal account. This",
+        "instruction can only be called by the `owner` or `owner_assistant`.",
         "# Arguments",
         "",
         "* `ctx` - `CloseProposal` context."
@@ -767,7 +767,7 @@ export type MatchingEngine = {
       "name": "updateFeeRecipient",
       "docs": [
         "This instruction is used to update the `fee_recipient` field in the `Custodian` account. This",
-        "instruction can only be called by the `owner`.",
+        "instruction can only be called by the `owner` or `owner_assistant`.",
         "# Arguments",
         "",
         "* `ctx` - `UpdateFeeRecipient` context."
@@ -1539,12 +1539,42 @@ export type MatchingEngine = {
           ]
         },
         {
-          "name": "fastVaa",
+          "name": "fastOrderPath",
           "accounts": [
             {
-              "name": "vaa",
-              "isMut": false,
-              "isSigner": false
+              "name": "fastVaa",
+              "accounts": [
+                {
+                  "name": "vaa",
+                  "isMut": false,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "path",
+              "accounts": [
+                {
+                  "name": "fromEndpoint",
+                  "accounts": [
+                    {
+                      "name": "endpoint",
+                      "isMut": false,
+                      "isSigner": false
+                    }
+                  ]
+                },
+                {
+                  "name": "toEndpoint",
+                  "accounts": [
+                    {
+                      "name": "endpoint",
+                      "isMut": false,
+                      "isSigner": false
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -4071,8 +4101,8 @@ export const IDL: MatchingEngine = {
     {
       "name": "closeProposal",
       "docs": [
-        "This instruction is used to close an existing proposal by closing the propsal account. This",
-        "instruction can only be called by the `owner`.",
+        "This instruction is used to close an existing proposal by closing the proposal account. This",
+        "instruction can only be called by the `owner` or `owner_assistant`.",
         "# Arguments",
         "",
         "* `ctx` - `CloseProposal` context."
@@ -4152,7 +4182,7 @@ export const IDL: MatchingEngine = {
       "name": "updateFeeRecipient",
       "docs": [
         "This instruction is used to update the `fee_recipient` field in the `Custodian` account. This",
-        "instruction can only be called by the `owner`.",
+        "instruction can only be called by the `owner` or `owner_assistant`.",
         "# Arguments",
         "",
         "* `ctx` - `UpdateFeeRecipient` context."
@@ -4924,12 +4954,42 @@ export const IDL: MatchingEngine = {
           ]
         },
         {
-          "name": "fastVaa",
+          "name": "fastOrderPath",
           "accounts": [
             {
-              "name": "vaa",
-              "isMut": false,
-              "isSigner": false
+              "name": "fastVaa",
+              "accounts": [
+                {
+                  "name": "vaa",
+                  "isMut": false,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "path",
+              "accounts": [
+                {
+                  "name": "fromEndpoint",
+                  "accounts": [
+                    {
+                      "name": "endpoint",
+                      "isMut": false,
+                      "isSigner": false
+                    }
+                  ]
+                },
+                {
+                  "name": "toEndpoint",
+                  "accounts": [
+                    {
+                      "name": "endpoint",
+                      "isMut": false,
+                      "isSigner": false
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -1852,46 +1852,6 @@ export type MatchingEngine = {
           ]
         },
         {
-          "name": "fastOrderPath",
-          "accounts": [
-            {
-              "name": "fastVaa",
-              "accounts": [
-                {
-                  "name": "vaa",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "path",
-              "accounts": [
-                {
-                  "name": "fromEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                },
-                {
-                  "name": "toEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
           "name": "auction",
           "isMut": true,
           "isSigner": false,
@@ -2090,46 +2050,6 @@ export type MatchingEngine = {
               "name": "custodyToken",
               "isMut": true,
               "isSigner": false
-            }
-          ]
-        },
-        {
-          "name": "fastOrderPath",
-          "accounts": [
-            {
-              "name": "fastVaa",
-              "accounts": [
-                {
-                  "name": "vaa",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "path",
-              "accounts": [
-                {
-                  "name": "fromEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                },
-                {
-                  "name": "toEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                }
-              ]
             }
           ]
         },
@@ -2506,25 +2426,20 @@ export type MatchingEngine = {
             "type": "u8"
           },
           {
-            "name": "fastVaaHash",
+            "name": "info",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "defined": "PreparedOrderResponseInfo"
             }
           },
           {
-            "name": "preparedBy",
-            "type": "publicKey"
+            "name": "toEndpoint",
+            "type": {
+              "defined": "EndpointInfo"
+            }
           },
           {
-            "name": "sourceChain",
-            "type": "u16"
-          },
-          {
-            "name": "baseFee",
-            "type": "u64"
+            "name": "redeemerMessage",
+            "type": "bytes"
           }
         ]
       }
@@ -2611,44 +2526,9 @@ export type MatchingEngine = {
             "type": "u8"
           },
           {
-            "name": "chain",
-            "docs": [
-              "Emitter chain. Cannot equal `1` (Solana's Chain ID)."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "address",
-            "docs": [
-              "Emitter address. Cannot be zero address."
-            ],
+            "name": "info",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "mintRecipient",
-            "docs": [
-              "Future-proof field in case another network has token accounts to send assets to instead of",
-              "sending to the address directly."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "protocol",
-            "docs": [
-              "Specific message protocol used to move assets."
-            ],
-            "type": {
-              "defined": "MessageProtocol"
+              "defined": "EndpointInfo"
             }
           }
         ]
@@ -2894,6 +2774,114 @@ export type MatchingEngine = {
               "option": {
                 "defined": "AuctionDestinationAssetInfo"
               }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PreparedOrderResponseInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fastVaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "preparedBy",
+            "type": "publicKey"
+          },
+          {
+            "name": "fastVaaTimestamp",
+            "type": "u32"
+          },
+          {
+            "name": "sourceChain",
+            "type": "u16"
+          },
+          {
+            "name": "baseFee",
+            "type": "u64"
+          },
+          {
+            "name": "initAuctionFee",
+            "type": "u64"
+          },
+          {
+            "name": "sender",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "redeemer",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "amountIn",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EndpointInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain",
+            "docs": [
+              "Emitter chain. Cannot equal `1` (Solana's Chain ID)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "address",
+            "docs": [
+              "Emitter address. Cannot be zero address."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "mintRecipient",
+            "docs": [
+              "Future-proof field in case another network has token accounts to send assets to instead of",
+              "sending to the address directly."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "protocol",
+            "docs": [
+              "Specific message protocol used to move assets."
+            ],
+            "type": {
+              "defined": "MessageProtocol"
             }
           }
         ]
@@ -3237,6 +3225,10 @@ export type MatchingEngine = {
     {
       "code": 6076,
       "name": "VaaMismatch"
+    },
+    {
+      "code": 6078,
+      "name": "RedeemerMessageTooLarge"
     },
     {
       "code": 6096,
@@ -5267,46 +5259,6 @@ export const IDL: MatchingEngine = {
           ]
         },
         {
-          "name": "fastOrderPath",
-          "accounts": [
-            {
-              "name": "fastVaa",
-              "accounts": [
-                {
-                  "name": "vaa",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "path",
-              "accounts": [
-                {
-                  "name": "fromEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                },
-                {
-                  "name": "toEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
           "name": "auction",
           "isMut": true,
           "isSigner": false,
@@ -5505,46 +5457,6 @@ export const IDL: MatchingEngine = {
               "name": "custodyToken",
               "isMut": true,
               "isSigner": false
-            }
-          ]
-        },
-        {
-          "name": "fastOrderPath",
-          "accounts": [
-            {
-              "name": "fastVaa",
-              "accounts": [
-                {
-                  "name": "vaa",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "path",
-              "accounts": [
-                {
-                  "name": "fromEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                },
-                {
-                  "name": "toEndpoint",
-                  "accounts": [
-                    {
-                      "name": "endpoint",
-                      "isMut": false,
-                      "isSigner": false
-                    }
-                  ]
-                }
-              ]
             }
           ]
         },
@@ -5921,25 +5833,20 @@ export const IDL: MatchingEngine = {
             "type": "u8"
           },
           {
-            "name": "fastVaaHash",
+            "name": "info",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "defined": "PreparedOrderResponseInfo"
             }
           },
           {
-            "name": "preparedBy",
-            "type": "publicKey"
+            "name": "toEndpoint",
+            "type": {
+              "defined": "EndpointInfo"
+            }
           },
           {
-            "name": "sourceChain",
-            "type": "u16"
-          },
-          {
-            "name": "baseFee",
-            "type": "u64"
+            "name": "redeemerMessage",
+            "type": "bytes"
           }
         ]
       }
@@ -6026,44 +5933,9 @@ export const IDL: MatchingEngine = {
             "type": "u8"
           },
           {
-            "name": "chain",
-            "docs": [
-              "Emitter chain. Cannot equal `1` (Solana's Chain ID)."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "address",
-            "docs": [
-              "Emitter address. Cannot be zero address."
-            ],
+            "name": "info",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "mintRecipient",
-            "docs": [
-              "Future-proof field in case another network has token accounts to send assets to instead of",
-              "sending to the address directly."
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "protocol",
-            "docs": [
-              "Specific message protocol used to move assets."
-            ],
-            "type": {
-              "defined": "MessageProtocol"
+              "defined": "EndpointInfo"
             }
           }
         ]
@@ -6309,6 +6181,114 @@ export const IDL: MatchingEngine = {
               "option": {
                 "defined": "AuctionDestinationAssetInfo"
               }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PreparedOrderResponseInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fastVaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "preparedBy",
+            "type": "publicKey"
+          },
+          {
+            "name": "fastVaaTimestamp",
+            "type": "u32"
+          },
+          {
+            "name": "sourceChain",
+            "type": "u16"
+          },
+          {
+            "name": "baseFee",
+            "type": "u64"
+          },
+          {
+            "name": "initAuctionFee",
+            "type": "u64"
+          },
+          {
+            "name": "sender",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "redeemer",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "amountIn",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EndpointInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "chain",
+            "docs": [
+              "Emitter chain. Cannot equal `1` (Solana's Chain ID)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "address",
+            "docs": [
+              "Emitter address. Cannot be zero address."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "mintRecipient",
+            "docs": [
+              "Future-proof field in case another network has token accounts to send assets to instead of",
+              "sending to the address directly."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "protocol",
+            "docs": [
+              "Specific message protocol used to move assets."
+            ],
+            "type": {
+              "defined": "MessageProtocol"
             }
           }
         ]
@@ -6652,6 +6632,10 @@ export const IDL: MatchingEngine = {
     {
       "code": 6076,
       "name": "VaaMismatch"
+    },
+    {
+      "code": 6078,
+      "name": "RedeemerMessageTooLarge"
     },
     {
       "code": 6096,

--- a/solana/target/types/token_router.ts
+++ b/solana/target/types/token_router.ts
@@ -1347,6 +1347,10 @@ export type TokenRouter = {
       "name": "InvalidPayloadId"
     },
     {
+      "code": 6078,
+      "name": "RedeemerMessageTooLarge"
+    },
+    {
       "code": 6096,
       "name": "InvalidSourceRouter"
     },
@@ -2752,6 +2756,10 @@ export const IDL: TokenRouter = {
     {
       "code": 6070,
       "name": "InvalidPayloadId"
+    },
+    {
+      "code": 6078,
+      "name": "RedeemerMessageTooLarge"
     },
     {
       "code": 6096,

--- a/solana/ts/src/common/messages/index.ts
+++ b/solana/ts/src/common/messages/index.ts
@@ -69,9 +69,10 @@ export class LiquidityLayerMessage {
                     const redeemer = Array.from(buf.subarray(offset, (offset += 32)));
                     const sender = Array.from(buf.subarray(offset, (offset += 32)));
                     const refundAddress = Array.from(buf.subarray(offset, (offset += 32)));
-                    const maxFee = buf.readBigInt64BE(offset);
+                    const maxFee = buf.readBigUInt64BE(offset);
                     offset += 8;
-                    const initAuctionFee = buf.readBigInt64BE(offset);
+                    const initAuctionFee = buf.readBigUInt64BE(offset);
+                    offset += 8;
                     const deadline = buf.readUInt32BE(offset);
                     offset += 4;
                     const redeemerMessageLen = buf.readUInt32BE(offset);

--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -1208,6 +1208,14 @@ export class MatchingEngineProgram {
         const { payer, fastVaa, finalizedVaa } = accounts;
 
         const fastVaaAcct = await VaaAccount.fetch(this.program.provider.connection, fastVaa);
+        const fromEndpoint = this.routerEndpointAddress(fastVaaAcct.emitterInfo().chain);
+
+        const { fastMarketOrder } = LiquidityLayerMessage.decode(fastVaaAcct.payload());
+        if (fastMarketOrder === undefined) {
+            throw new Error("Message not FastMarketOrder");
+        }
+        const toEndpoint = this.routerEndpointAddress(fastMarketOrder.targetChain);
+
         const { encodedCctpMessage } = args;
         const {
             authority: messageTransmitterAuthority,
@@ -1234,7 +1242,7 @@ export class MatchingEngineProgram {
             .accounts({
                 payer,
                 custodian: this.checkedCustodianComposite(),
-                fastVaa: this.liquidityLayerVaaComposite(fastVaa),
+                fastOrderPath: this.fastOrderPathComposite({ fastVaa, fromEndpoint, toEndpoint }),
                 finalizedVaa: this.liquidityLayerVaaComposite(finalizedVaa),
                 preparedOrderResponse,
                 preparedCustodyToken: this.preparedCustodyTokenAddress(preparedOrderResponse),

--- a/solana/ts/src/matchingEngine/state/PreparedOrderResponse.ts
+++ b/solana/ts/src/matchingEngine/state/PreparedOrderResponse.ts
@@ -1,25 +1,36 @@
 import { BN } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
 import { VaaHash } from "../../common";
-export class PreparedOrderResponse {
-    bump: number;
+import { EndpointInfo } from "./RouterEndpoint";
+
+export type PreparedOrderResponseInfo = {
     preparedBy: PublicKey;
     fastVaaHash: Array<number>;
+    fastVaaTimestamp: number;
     sourceChain: number;
     baseFee: BN;
+    initAuctionFee: BN;
+    sender: Array<number>;
+    redeemer: Array<number>;
+    amountIn: BN;
+};
+
+export class PreparedOrderResponse {
+    bump: number;
+    info: PreparedOrderResponseInfo;
+    toEndpoint: EndpointInfo;
+    redeemerMessage: Buffer;
 
     constructor(
         bump: number,
-        preparedBy: PublicKey,
-        fastVaaHash: Array<number>,
-        sourceChain: number,
-        baseFee: BN,
+        info: PreparedOrderResponseInfo,
+        toEndpoint: EndpointInfo,
+        redeemerMessage: Buffer,
     ) {
         this.bump = bump;
-        this.preparedBy = preparedBy;
-        this.fastVaaHash = fastVaaHash;
-        this.sourceChain = sourceChain;
-        this.baseFee = baseFee;
+        this.info = info;
+        this.toEndpoint = toEndpoint;
+        this.redeemerMessage = redeemerMessage;
     }
 
     static address(programId: PublicKey, fastVaaHash: VaaHash) {

--- a/solana/ts/src/matchingEngine/state/RouterEndpoint.ts
+++ b/solana/ts/src/matchingEngine/state/RouterEndpoint.ts
@@ -6,25 +6,20 @@ export type MessageProtocol = {
     none?: {};
 };
 
-export class RouterEndpoint {
-    bump: number;
+export type EndpointInfo = {
     chain: number;
     address: Array<number>;
     mintRecipient: Array<number>;
     protocol: MessageProtocol;
+};
 
-    constructor(
-        bump: number,
-        chain: number,
-        address: Array<number>,
-        mintRecipient: Array<number>,
-        protocol: MessageProtocol,
-    ) {
+export class RouterEndpoint {
+    bump: number;
+    info: EndpointInfo;
+
+    constructor(bump: number, info: EndpointInfo) {
         this.bump = bump;
-        this.chain = chain;
-        this.address = address;
-        this.mintRecipient = mintRecipient;
-        this.protocol = protocol;
+        this.info = info;
     }
 
     static address(programId: PublicKey, chain: number) {

--- a/solana/ts/src/tokenRouter/index.ts
+++ b/solana/ts/src/tokenRouter/index.ts
@@ -468,7 +468,7 @@ export class TokenRouterProgram {
         const cctpMessage = this.cctpMessageAddress(preparedOrder);
 
         if (destinationDomain === undefined) {
-            const { protocol } = await matchingEngine.fetchRouterEndpoint({
+            const { protocol } = await matchingEngine.fetchRouterEndpointInfo({
                 address: routerEndpoint,
             });
             if (protocol.cctp === undefined) {

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -4559,6 +4559,10 @@ describe("Matching Engine", function () {
             }
         })();
 
+        const { value: lookupTableAccount } = await connection.getAddressLookupTable(
+            lookupTableAddress,
+        );
+
         const placeAndExecute = async () => {
             if (placeInitialOffer) {
                 const result = await placeInitialOfferCctpForTest(
@@ -4599,9 +4603,6 @@ describe("Matching Engine", function () {
                         units: 300_000,
                     });
 
-                    const { value: lookupTableAccount } = await connection.getAddressLookupTable(
-                        lookupTableAddress,
-                    );
                     const ix = await engine.executeFastOrderCctpIx({
                         payer: payer.publicKey,
                         fastVaa,
@@ -4632,7 +4633,9 @@ describe("Matching Engine", function () {
 
         if (errorMsg !== null) {
             expect(instructionOnly).is.false;
-            return expectIxErr(connection, [ix], signers, errorMsg);
+            return expectIxErr(connection, [ix], signers, errorMsg, {
+                addressLookupTableAccounts: [lookupTableAccount!],
+            });
         }
 
         const preparedOrderResponse = engine.preparedOrderResponseAddress(fastVaaAccount.digest());
@@ -4665,9 +4668,6 @@ describe("Matching Engine", function () {
         const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
             units: 280_000,
         });
-        const { value: lookupTableAccount } = await connection.getAddressLookupTable(
-            lookupTableAddress,
-        );
         await expectIxOk(connection, [computeIx, ix], signers, {
             addressLookupTableAccounts: [lookupTableAccount!],
         });

--- a/solana/ts/tests/02__tokenRouter.ts
+++ b/solana/ts/tests/02__tokenRouter.ts
@@ -1020,7 +1020,7 @@ describe("Token Router", function () {
 
                 const {
                     protocol: { cctp: cctpProtocol },
-                } = await tokenRouter.matchingEngineProgram().fetchRouterEndpoint(foreignChain);
+                } = await tokenRouter.matchingEngineProgram().fetchRouterEndpointInfo(foreignChain);
                 expect(cctpProtocol).is.not.null;
                 const { domain: destinationCctpDomain } = cctpProtocol!;
 

--- a/solana/ts/tests/04__interaction.ts
+++ b/solana/ts/tests/04__interaction.ts
@@ -128,13 +128,14 @@ describe("Matching Engine <> Token Router", function () {
                 );
                 const { bump } = routerEndpointData;
                 expect(routerEndpointData).to.eql(
-                    new matchingEngineSdk.RouterEndpoint(
-                        bump,
-                        wormholeSdk.CHAIN_ID_SOLANA,
-                        Array.from(tokenRouter.custodianAddress().toBuffer()),
-                        Array.from(tokenRouter.cctpMintRecipientAddress().toBuffer()),
-                        { local: { programId: tokenRouter.ID } },
-                    ),
+                    new matchingEngineSdk.RouterEndpoint(bump, {
+                        chain: wormholeSdk.CHAIN_ID_SOLANA,
+                        address: Array.from(tokenRouter.custodianAddress().toBuffer()),
+                        mintRecipient: Array.from(
+                            tokenRouter.cctpMintRecipientAddress().toBuffer(),
+                        ),
+                        protocol: { local: { programId: tokenRouter.ID } },
+                    }),
                 );
 
                 // Save for later.
@@ -180,13 +181,14 @@ describe("Matching Engine <> Token Router", function () {
                 );
                 const { bump } = routerEndpointData;
                 expect(routerEndpointData).to.eql(
-                    new matchingEngineSdk.RouterEndpoint(
-                        bump,
-                        wormholeSdk.CHAIN_ID_SOLANA,
-                        Array.from(tokenRouter.custodianAddress().toBuffer()),
-                        Array.from(tokenRouter.cctpMintRecipientAddress().toBuffer()),
-                        { local: { programId: tokenRouter.ID } },
-                    ),
+                    new matchingEngineSdk.RouterEndpoint(bump, {
+                        chain: wormholeSdk.CHAIN_ID_SOLANA,
+                        address: Array.from(tokenRouter.custodianAddress().toBuffer()),
+                        mintRecipient: Array.from(
+                            tokenRouter.cctpMintRecipientAddress().toBuffer(),
+                        ),
+                        protocol: { local: { programId: tokenRouter.ID } },
+                    }),
                 );
             });
 
@@ -213,13 +215,12 @@ describe("Matching Engine <> Token Router", function () {
                 );
                 const { bump } = routerEndpointData;
                 expect(routerEndpointData).to.eql(
-                    new matchingEngineSdk.RouterEndpoint(
-                        bump,
-                        wormholeSdk.CHAIN_ID_SOLANA,
-                        new Array(32).fill(0),
-                        new Array(32).fill(0),
-                        { none: {} },
-                    ),
+                    new matchingEngineSdk.RouterEndpoint(bump, {
+                        chain: wormholeSdk.CHAIN_ID_SOLANA,
+                        address: new Array(32).fill(0),
+                        mintRecipient: new Array(32).fill(0),
+                        protocol: { none: {} },
+                    }),
                 );
             });
 
@@ -495,13 +496,14 @@ describe("Matching Engine <> Token Router", function () {
                 );
                 const { bump } = routerEndpointData;
                 expect(routerEndpointData).to.eql(
-                    new matchingEngineSdk.RouterEndpoint(
-                        bump,
-                        wormholeSdk.CHAIN_ID_SOLANA,
-                        Array.from(tokenRouter.custodianAddress().toBuffer()),
-                        Array.from(tokenRouter.cctpMintRecipientAddress().toBuffer()),
-                        { local: { programId: tokenRouter.ID } },
-                    ),
+                    new matchingEngineSdk.RouterEndpoint(bump, {
+                        chain: wormholeSdk.CHAIN_ID_SOLANA,
+                        address: Array.from(tokenRouter.custodianAddress().toBuffer()),
+                        mintRecipient: Array.from(
+                            tokenRouter.cctpMintRecipientAddress().toBuffer(),
+                        ),
+                        protocol: { local: { programId: tokenRouter.ID } },
+                    }),
                 );
             });
 

--- a/universal/rs/Cargo.toml
+++ b/universal/rs/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://wormhole.com"
 repository = "https://github.com/wormhole-foundation/example-liquidity-layer"
 
 [workspace.dependencies]
-wormhole-io = "0.1.2"
+wormhole-io = "0.2.0-alpha.3"
 wormhole-raw-vaas = "0.2.0-alpha.2"
 hex-literal = "0.4.1"
 

--- a/universal/rs/messages/src/deposit/slow_order_response.rs
+++ b/universal/rs/messages/src/deposit/slow_order_response.rs
@@ -8,8 +8,6 @@ pub struct SlowOrderResponse {
 }
 
 impl Readable for SlowOrderResponse {
-    const SIZE: Option<usize> = Some(8);
-
     fn read<R>(reader: &mut R) -> std::io::Result<Self>
     where
         Self: Sized,
@@ -22,22 +20,21 @@ impl Readable for SlowOrderResponse {
 }
 
 impl Writeable for SlowOrderResponse {
-    fn written_size(&self) -> usize {
-        <Self as Readable>::SIZE.unwrap()
-    }
-
     fn write<W>(&self, writer: &mut W) -> std::io::Result<()>
     where
         Self: Sized,
         W: std::io::Write,
     {
-        self.base_fee.write(writer)?;
-        Ok(())
+        self.base_fee.write(writer)
     }
 }
 
-impl TypePrefixedPayload for SlowOrderResponse {
-    const TYPE: Option<u8> = Some(2);
+impl TypePrefixedPayload<1> for SlowOrderResponse {
+    const TYPE: Option<[u8; 1]> = Some([2]);
+
+    fn written_size(&self) -> usize {
+        8
+    }
 }
 
 #[cfg(test)]
@@ -54,7 +51,8 @@ mod test {
 
         let encoded = slow_order_response.to_vec();
 
-        let parsed = raw::SlowOrderResponse::parse(&encoded).unwrap();
+        let message = raw::LiquidityLayerDepositMessage::parse(&encoded).unwrap();
+        let parsed = message.to_slow_order_response_unchecked();
 
         let expected = SlowOrderResponse {
             base_fee: parsed.base_fee(),


### PR DESCRIPTION
Several things:
* Upticked wormhole-io to latest alpha version
* Fixed bug in typescript FastMarketOrder deserialization
* Changed schema to PreparedOrderResponse
* Removed FastOrderPath composite from settle auction none instructions (since the path is now verified in the prepare order response instruction)

I recommend reviewing the changes by going through each commit in order because this ended up being a big change.

NOTE: I organized the RouterEndpoint account to have a separate `info` field. Serialization is the same as before, so this will not impact the deployment on Solana devnet.