### PR TITLE
solana: fix lamport beneficiaries

### DIFF
--- a/solana/.gitignore
+++ b/solana/.gitignore
@@ -1,5 +1,6 @@
 .anchor
 .env
+.validator_pid
 **/*.rs.bk
 /artifacts-*
 /cfg/**/*.json

--- a/solana/programs/matching-engine/src/composite/mod.rs
+++ b/solana/programs/matching-engine/src/composite/mod.rs
@@ -380,6 +380,11 @@ pub struct ExecuteOrder<'info> {
         address = active_auction.info.as_ref().unwrap().initial_offer_token,
     )]
     pub initial_offer_token: UncheckedAccount<'info>,
+
+    /// CHECK: Must be the owner of initial offer token account. If the initial offer token account
+    /// does not exist anymore, we will attempt to perform this check.
+    #[account(mut)]
+    pub initial_participant: UncheckedAccount<'info>,
 }
 
 #[derive(Accounts)]

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
@@ -81,14 +81,7 @@ pub fn handle_execute_fast_order_cctp(
         fill,
         beneficiary,
     } = super::prepare_order_execution(super::PrepareFastExecution {
-        auction: &mut ctx.accounts.execute_order.active_auction.auction,
-        fast_vaa: &ctx.accounts.execute_order.fast_vaa,
-        custody_token: &ctx.accounts.execute_order.active_auction.custody_token,
-        config: &ctx.accounts.execute_order.active_auction.config,
-        executor_token: &ctx.accounts.execute_order.executor_token,
-        best_offer_token: &ctx.accounts.execute_order.active_auction.best_offer_token,
-        initial_offer_token: &ctx.accounts.execute_order.initial_offer_token,
-        initial_participant: &ctx.accounts.execute_order.initial_participant,
+        execute_order: &mut ctx.accounts.execute_order,
         custodian: &ctx.accounts.custodian,
         token_program: &ctx.accounts.token_program,
     })?;

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
@@ -81,7 +81,14 @@ pub fn handle_execute_fast_order_cctp(
         fill,
         beneficiary,
     } = super::prepare_order_execution(super::PrepareFastExecution {
-        execute_order: &mut ctx.accounts.execute_order,
+        auction: &mut ctx.accounts.execute_order.active_auction.auction,
+        fast_vaa: &ctx.accounts.execute_order.fast_vaa,
+        custody_token: &ctx.accounts.execute_order.active_auction.custody_token,
+        config: &ctx.accounts.execute_order.active_auction.config,
+        executor_token: &ctx.accounts.execute_order.executor_token,
+        best_offer_token: &ctx.accounts.execute_order.active_auction.best_offer_token,
+        initial_offer_token: &ctx.accounts.execute_order.initial_offer_token,
+        initial_participant: &ctx.accounts.execute_order.initial_participant,
         custodian: &ctx.accounts.custodian,
         token_program: &ctx.accounts.token_program,
     })?;

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/cctp.rs
@@ -79,6 +79,7 @@ pub fn handle_execute_fast_order_cctp(
     let super::PreparedOrderExecution {
         user_amount: amount,
         fill,
+        beneficiary,
     } = super::prepare_order_execution(super::PrepareFastExecution {
         execute_order: &mut ctx.accounts.execute_order,
         custodian: &ctx.accounts.custodian,
@@ -187,7 +188,7 @@ pub fn handle_execute_fast_order_cctp(
         token_program.to_account_info(),
         token::CloseAccount {
             account: auction_custody_token.to_account_info(),
-            destination: payer.to_account_info(),
+            destination: beneficiary.unwrap_or(payer.to_account_info()),
             authority: custodian.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
@@ -60,6 +60,7 @@ pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<(
     let super::PreparedOrderExecution {
         user_amount: amount,
         fill,
+        beneficiary,
     } = super::prepare_order_execution(super::PrepareFastExecution {
         execute_order: &mut ctx.accounts.execute_order,
         custodian,
@@ -108,7 +109,7 @@ pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<(
         token_program.to_account_info(),
         token::CloseAccount {
             account: auction_custody_token.to_account_info(),
-            destination: payer.to_account_info(),
+            destination: beneficiary.unwrap_or(payer.to_account_info()),
             authority: custodian.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
@@ -62,14 +62,7 @@ pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<(
         fill,
         beneficiary,
     } = super::prepare_order_execution(super::PrepareFastExecution {
-        auction: &mut ctx.accounts.execute_order.active_auction.auction,
-        fast_vaa: &ctx.accounts.execute_order.fast_vaa,
-        custody_token: &ctx.accounts.execute_order.active_auction.custody_token,
-        config: &ctx.accounts.execute_order.active_auction.config,
-        executor_token: &ctx.accounts.execute_order.executor_token,
-        best_offer_token: &ctx.accounts.execute_order.active_auction.best_offer_token,
-        initial_offer_token: &ctx.accounts.execute_order.initial_offer_token,
-        initial_participant: &ctx.accounts.execute_order.initial_participant,
+        execute_order: &mut ctx.accounts.execute_order,
         custodian,
         token_program,
     })?;

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/local.rs
@@ -62,7 +62,14 @@ pub fn execute_fast_order_local(ctx: Context<ExecuteFastOrderLocal>) -> Result<(
         fill,
         beneficiary,
     } = super::prepare_order_execution(super::PrepareFastExecution {
-        execute_order: &mut ctx.accounts.execute_order,
+        auction: &mut ctx.accounts.execute_order.active_auction.auction,
+        fast_vaa: &ctx.accounts.execute_order.fast_vaa,
+        custody_token: &ctx.accounts.execute_order.active_auction.custody_token,
+        config: &ctx.accounts.execute_order.active_auction.config,
+        executor_token: &ctx.accounts.execute_order.executor_token,
+        best_offer_token: &ctx.accounts.execute_order.active_auction.best_offer_token,
+        initial_offer_token: &ctx.accounts.execute_order.initial_offer_token,
+        initial_participant: &ctx.accounts.execute_order.initial_participant,
         custodian,
         token_program,
     })?;

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
@@ -107,11 +107,11 @@ fn prepare_order_execution<'info>(
         // If the initial offer token account doesn't exist anymore, we have nowhere to send the
         // init auction fee. The executor will get these funds instead.
         if !initial_offer_token.data_is_empty() {
-            // First deserialize to token account to find owner. If data is not empty, this should
-            // always succeed.
+            // Deserialize to token account to find owner. We know this is a legitimate token
+            // account, so it is safe to borrow and unwrap here.
             {
-                let mut acc_data: &[_] = &initial_offer_token.try_borrow_data()?;
-                let token_data = token::TokenAccount::try_deserialize(&mut acc_data)?;
+                let mut acc_data: &[_] = &initial_offer_token.data.borrow();
+                let token_data = token::TokenAccount::try_deserialize(&mut acc_data).unwrap();
                 require_keys_eq!(
                     token_data.owner,
                     initial_participant.key(),

--- a/solana/programs/matching-engine/src/processor/auction/settle/none/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/none/cctp.rs
@@ -84,6 +84,7 @@ fn handle_settle_auction_none_cctp(
     ctx: Context<SettleAuctionNoneCctp>,
     destination_cctp_domain: u32,
 ) -> Result<()> {
+    let prepared_by = &ctx.accounts.prepared.by;
     let prepared_custody_token = &ctx.accounts.prepared.custody_token;
     let custodian = &ctx.accounts.custodian;
     let token_program = &ctx.accounts.token_program;
@@ -206,7 +207,7 @@ fn handle_settle_auction_none_cctp(
         token_program.to_account_info(),
         token::CloseAccount {
             account: prepared_custody_token.to_account_info(),
-            destination: payer.to_account_info(),
+            destination: prepared_by.to_account_info(),
             authority: custodian.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],

--- a/solana/programs/matching-engine/src/processor/auction/settle/none/local.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/none/local.rs
@@ -70,6 +70,7 @@ pub struct SettleAuctionNoneLocal<'info> {
 }
 
 pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result<()> {
+    let prepared_by = &ctx.accounts.prepared.by;
     let prepared_custody_token = &ctx.accounts.prepared.custody_token;
     let custodian = &ctx.accounts.custodian;
     let token_program = &ctx.accounts.token_program;
@@ -124,7 +125,7 @@ pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result
         token_program.to_account_info(),
         token::CloseAccount {
             account: prepared_custody_token.to_account_info(),
-            destination: payer.to_account_info(),
+            destination: prepared_by.to_account_info(),
             authority: custodian.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],

--- a/solana/programs/token-router/src/processor/market_order/place_cctp.rs
+++ b/solana/programs/token-router/src/processor/market_order/place_cctp.rs
@@ -290,7 +290,7 @@ fn handle_place_market_order_cctp(
         token_program.to_account_info(),
         token::CloseAccount {
             account: prepared_custody_token.to_account_info(),
-            destination: payer.to_account_info(),
+            destination: ctx.accounts.prepared_by.to_account_info(),
             authority: custodian.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],

--- a/solana/target/idl/matching_engine.json
+++ b/solana/target/idl/matching_engine.json
@@ -643,6 +643,13 @@
             {
               "name": "initial_offer_token",
               "writable": true
+            },
+            {
+              "name": "initial_participant",
+              "docs": [
+                "does not exist anymore, we will attempt to perform this check."
+              ],
+              "writable": true
             }
           ]
         },
@@ -830,6 +837,13 @@
             },
             {
               "name": "initial_offer_token",
+              "writable": true
+            },
+            {
+              "name": "initial_participant",
+              "docs": [
+                "does not exist anymore, we will attempt to perform this check."
+              ],
               "writable": true
             }
           ]

--- a/solana/target/types/matching_engine.ts
+++ b/solana/target/types/matching_engine.ts
@@ -649,6 +649,13 @@ export type MatchingEngine = {
             {
               "name": "initialOfferToken",
               "writable": true
+            },
+            {
+              "name": "initialParticipant",
+              "docs": [
+                "does not exist anymore, we will attempt to perform this check."
+              ],
+              "writable": true
             }
           ]
         },
@@ -836,6 +843,13 @@ export type MatchingEngine = {
             },
             {
               "name": "initialOfferToken",
+              "writable": true
+            },
+            {
+              "name": "initialParticipant",
+              "docs": [
+                "does not exist anymore, we will attempt to perform this check."
+              ],
               "writable": true
             }
           ]

--- a/solana/ts/tests/01__matchingEngine.ts
+++ b/solana/ts/tests/01__matchingEngine.ts
@@ -2544,6 +2544,7 @@ describe("Matching Engine", function () {
                 const ix = await engine.executeFastOrderCctpIx({
                     payer: liquidator.publicKey,
                     fastVaa,
+                    initialParticipant: payer.publicKey,
                 });
 
                 const computeIx = ComputeBudgetProgram.setComputeUnitLimit({


### PR DESCRIPTION
* Execute order should send auction custody token account lamports to the owner of the initial offer token if it exists
* Settle auction none should send prepared custody token lamports to prepared_by encoded in `PreparedOrderResponse`
* Place order CCTP should send prepared order token account lamports to prepared_by encoded in `PreparedOrder`

Closes #104.