### PR TITLE
solana: add sender option

### DIFF
--- a/solana/programs/token-router/src/error.rs
+++ b/solana/programs/token-router/src/error.rs
@@ -25,6 +25,8 @@ pub enum TokenRouterError {
     AlreadyOwner = 0x204,
     NoTransferOwnershipRequest = 0x206,
     NotPendingOwner = 0x208,
+    MissingAuthority = 0x20a,
+    TooManyAuthorities = 0x20b,
 
     InsufficientAmount = 0x400,
     MinAmountOutTooHigh = 0x402,

--- a/solana/target/idl/token_router.json
+++ b/solana/target/idl/token_router.json
@@ -522,11 +522,22 @@
           ]
         },
         {
-          "name": "transfer_authority",
+          "name": "program_transfer_authority",
           "docs": [
-            "The auction participant needs to set approval to this PDA.",
+            "The auction participant needs to set approval to this PDA if the sender (signer) is not",
+            "provided.",
             ""
-          ]
+          ],
+          "optional": true
+        },
+        {
+          "name": "sender",
+          "docs": [
+            "Sender, who has the authority to transfer assets from the sender token account. If this",
+            "account is not provided, the program transfer authority account must be some account."
+          ],
+          "signer": true,
+          "optional": true
         },
         {
           "name": "prepared_order",
@@ -1122,6 +1133,14 @@
     {
       "code": 6520,
       "name": "NotPendingOwner"
+    },
+    {
+      "code": 6522,
+      "name": "TooManyAuthorities"
+    },
+    {
+      "code": 6524,
+      "name": "MissingAuthority"
     },
     {
       "code": 7024,

--- a/solana/target/types/token_router.ts
+++ b/solana/target/types/token_router.ts
@@ -528,11 +528,22 @@ export type TokenRouter = {
           ]
         },
         {
-          "name": "transferAuthority",
+          "name": "programTransferAuthority",
           "docs": [
-            "The auction participant needs to set approval to this PDA.",
+            "The auction participant needs to set approval to this PDA if the sender (signer) is not",
+            "provided.",
             ""
-          ]
+          ],
+          "optional": true
+        },
+        {
+          "name": "sender",
+          "docs": [
+            "Sender, who has the authority to transfer assets from the sender token account. If this",
+            "account is not provided, the program transfer authority account must be some account."
+          ],
+          "signer": true,
+          "optional": true
         },
         {
           "name": "preparedOrder",
@@ -1128,6 +1139,14 @@ export type TokenRouter = {
     {
       "code": 6520,
       "name": "notPendingOwner"
+    },
+    {
+      "code": 6522,
+      "name": "tooManyAuthorities"
+    },
+    {
+      "code": 6524,
+      "name": "missingAuthority"
     },
     {
       "code": 7024,


### PR DESCRIPTION
If an integrator were to compose with prepare market order instruction, it may be difficult (not impossible) to determine the transfer authority seeds.

This allows for an integrator to choose passing in a `sender`, who has authority to transfer assets from the sender token account OR a `program_transfer_authority`, which is the transfer authority that already existed. **Both cannot be specified.**