### PR TITLE
solana: use docker compose to host nats and beacon for solvers

### DIFF
--- a/solana/Makefile
+++ b/solana/Makefile
@@ -80,18 +80,21 @@ lint:
 	NETWORK=localnet $(MAKE) clippy
 	NETWORK=testnet $(MAKE) clippy
 
-.PHONY: run-spy
-wormhole-spy:
+.PHONY: wormhole-spy-up
+wormhole-spy-up:
 ifdef SPY_NETWORK_$(NETWORK)
-	docker run \
-		--platform=linux/amd64 \
-		-p 7073:7073 \
-		--entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy \
-		--nodeKey /node.key \
-		--spyRPC "[::]:7073" \
-		--network $(SPY_NETWORK_$(NETWORK)) \
-		--bootstrap $(SPY_BOOTSTRAP_$(NETWORK))
+	WORMHOLE_NETWORK_ID=$(SPY_NETWORK_$(NETWORK)) \
+	WORMHOLE_BOOTSTRAP=$(SPY_BOOTSTRAP_$(NETWORK)) \
+	NATS_STREAM="${NETWORK}-vaas" \
+	docker-compose -f docker-compose.yml up -d
 endif
+
+.PHONY: wormhole-spy-down
+wormhole-spy-down:
+	docker-compose -f docker-compose.yml down
+
+.PHONY: wormhole-spy-restart
+wormhole-spy-restart: wormhole-spy-down wormhole-spy-up
 
 ts/tests/artifacts:
 	mkdir ts/tests/artifacts

--- a/solana/README.md
+++ b/solana/README.md
@@ -87,11 +87,28 @@ associated with the auction's `FastMarketOrder` VAA. For the `vaaAuctionRelayer`
 fast transfers and execute the `settle_auction_complete` instruction, add the owner's public key to the
 `knownAtaOwners` array field in the configuration file.
 
-The `vaaAuctionRelayer` relies on the `VaaSpy` to listen for `FastMarketOrder` VAAs. To set up the
-`VaaSpy`, make sure Docker is running and execute the following command:
+The `vaaAuctionRelayer` relies on the [Beacon](https://github.com/pyth-network/beacon) as the `VaaSpy` to listen for `FastMarketOrder` VAAs. To set up the
+Beacon, increase the UDP buffer size for the OS:
 
 ```sh
-make wormhole-spy NETWORK=testnet
+# for linux
+sudo sysctl -w net.core.rmem_max=2097152
+sudo sysctl -w net.core.rmem_default=2097152
+# for macos
+sudo sysctl -w net.inet.udp.recvspace=2097152
+```
+
+Then, make sure Docker is running and execute the following command to run Beacon in a detached mode:
+
+```sh
+make wormhole-spy-up NETWORK=testnet
+```
+
+To stop or restart the beacon
+
+```sh
+make wormhole-spy-down
+make wormhole-spy-restart NETWORK=testnet
 ```
 
 To run the `vaaAuctionRelayer` execute the following command:

--- a/solana/docker-compose.yml
+++ b/solana/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+services:
+  nats:
+    container_name: solana-nats-1
+    image: nats:latest
+    command: --jetstream
+    ports:
+      - "4222:4222"
+
+  beacon:
+    container_name: solana-beacon-1
+    image: public.ecr.aws/pyth-network/beacon:v1.1.3
+    platform: linux/amd64
+    environment:
+      WORMHOLE_NETWORK_ID: ${WORMHOLE_NETWORK_ID}
+      WORMHOLE_BOOTSTRAP: ${WORMHOLE_BOOTSTRAP}
+      WORMHOLE_LISTEN_PORT: "8999"
+      NATS_URL: "solana-nats-1:4222"
+      NATS_STREAM: ${NATS_STREAM}
+      SERVER_URL: "0.0.0.0:7073"
+      LOG_LEVEL: "info"
+      WRITER_BATCH_SIZE: "1000"
+    ports:
+      - "7073:7073"
+    # required to let the container to increase UDP buffer size
+    # without giving it full root priviledges
+    cap_add:
+      - "NET_ADMIN"
+      


### PR DESCRIPTION
This PR uses [Beacon](https://github.com/pyth-network/beacon) by Pyth Network as `VaaSpy` instead of Wormhole Spy for improved spy availability and latency.
- `docker-compose.yml` to host both nats-server and Beacon
- add instruction to use Beacon