### PR TITLE
spy: fix parsed VAA type

### DIFF
--- a/solana/ts/auction-participant/vaaAuctionRelayer/app.ts
+++ b/solana/ts/auction-participant/vaaAuctionRelayer/app.ts
@@ -1,12 +1,12 @@
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import "dotenv/config";
 import * as fs from "fs";
-import { MatchingEngineProgram } from "../../src/matchingEngine";
-import { PreparedTransaction } from "../../src";
-import * as utils from "../utils";
 import * as winston from "winston";
+import { PreparedTransaction } from "../../src";
+import { MatchingEngineProgram } from "../../src/matchingEngine";
 import { VaaSpy } from "../../src/wormhole/spy";
 import { CachedBlockhash } from "../containers";
+import * as utils from "../utils";
 
 const MATCHING_ENGINE_PROGRAM_ID = "mPydpGUWxzERTNpyvTKdvS7v8kvw5sgwfiP8WQFrXVS";
 const USDC_MINT = new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
@@ -81,9 +81,7 @@ async function main(argv: string[]) {
 
             // Start a new auction if this is a fast VAA.
             logicLogger.debug(`Attempting to parse FastMarketOrder, sequence=${parsed.sequence}`);
-            const fastOrder = utils.tryParseFastMarketOrder(
-                Buffer.from(parsed.payload as Uint8Array),
-            );
+            const fastOrder = utils.tryParseFastMarketOrder(Buffer.from(parsed.payload));
             if (fastOrder !== undefined) {
                 const unprocessedTxns = await utils.handlePlaceInitialOffer(
                     connection,
@@ -102,9 +100,7 @@ async function main(argv: string[]) {
             }
         } else {
             logicLogger.debug(`Attempting to parse SlowOrderResponse, sequence=${parsed.sequence}`);
-            const slowOrderResponse = utils.tryParseSlowOrderResponse(
-                Buffer.from(parsed.payload as Uint8Array),
-            );
+            const slowOrderResponse = utils.tryParseSlowOrderResponse(Buffer.from(parsed.payload));
             if (slowOrderResponse !== undefined) {
                 const unprocessedTxns = await utils.handleSettleAuction(
                     connection,

--- a/solana/ts/src/wormhole/spy.ts
+++ b/solana/ts/src/wormhole/spy.ts
@@ -1,9 +1,9 @@
 import { createSpyRPCServiceClient, subscribeSignedVAA } from "@certusone/wormhole-spydk";
-import { deserialize, Chain, VAA, toChain, toUniversal, encoding } from "@wormhole-foundation/sdk";
+import { Chain, VAA, deserialize, encoding, toChain, toUniversal } from "@wormhole-foundation/sdk";
 
 export type VaaContext = {
     raw: Buffer;
-    parsed: VAA;
+    parsed: VAA<"Uint8Array">;
     chain?: Chain;
     nativeAddress?: string;
 };


### PR DESCRIPTION
This change allows us to reuse `VaaSpy` in our solver app in a type-safe way without type assertions.