### PR TITLE
solana: add explicit bn.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4092,6 +4092,7 @@
         "@wormhole-foundation/sdk-solana": "^0.7.0-beta.4",
         "@wormhole-foundation/sdk-solana-core": "^0.7.0-beta.4",
         "anchor-0.29.0": "npm:@coral-xyz/anchor@^0.29.0",
+        "bn.js": "^5.2.1",
         "dotenv": "^16.4.1",
         "ethers": "^5.7.2",
         "sha3": "^2.1.4",

--- a/solana/package.json
+++ b/solana/package.json
@@ -1,47 +1,48 @@
 {
-  "name":"@wormhole-foundation/example-liquidity-layer-solana",
+  "name": "@wormhole-foundation/example-liquidity-layer-solana",
   "version": "0.0.1",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
   "module": "dist/esm/index.js",
-  "files":[
+  "files": [
     "dist/cjs",
     "dist/esm"
   ],
-  "exports":{
-    ".":{
-      "import":"./dist/esm/index.js",
-      "require":"./dist/cjs/index.js",
-      "types":"./dist/cjs/index.d.ts"
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/cjs/index.d.ts"
     },
-    "./*":{
-      "import":"./dist/esm/*/index.js",
-      "require":"./dist/cjs/*/index.js",
-      "types":"./dist/cjs/*/index.d.ts"
+    "./*": {
+      "import": "./dist/esm/*/index.js",
+      "require": "./dist/cjs/*/index.js",
+      "types": "./dist/cjs/*/index.d.ts"
     }
   },
   "scripts": {
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
-    "build:esm":"npx tsc -p tsconfig.esm.json",
-    "build:cjs":"npx tsc -p tsconfig.cjs.json",
-    "build":"npm run build:esm && npm run build:cjs",
-    "clean":"rm -rf dist && rm -f ./*.tsbuildinfo && rm -rf node_modules"
+    "build:esm": "npx tsc -p tsconfig.esm.json",
+    "build:cjs": "npx tsc -p tsconfig.cjs.json",
+    "build": "npm run build:esm && npm run build:cjs",
+    "clean": "rm -rf dist && rm -f ./*.tsbuildinfo && rm -rf node_modules"
   },
   "dependencies": {
     "@certusone/wormhole-spydk": "^0.0.1",
     "@wormhole-foundation/example-liquidity-layer-definitions": "0.0.1",
-    "@wormhole-foundation/sdk-base":"^0.7.0-beta.4",
-    "@wormhole-foundation/sdk-definitions":"^0.7.0-beta.4",
-    "@wormhole-foundation/sdk-solana":"^0.7.0-beta.4",
-    "@wormhole-foundation/sdk-solana-core":"^0.7.0-beta.4",
+    "@wormhole-foundation/sdk-base": "^0.7.0-beta.4",
+    "@wormhole-foundation/sdk-definitions": "^0.7.0-beta.4",
+    "@wormhole-foundation/sdk-solana": "^0.7.0-beta.4",
+    "@wormhole-foundation/sdk-solana-core": "^0.7.0-beta.4",
     "@coral-xyz/anchor": "^0.30.0",
     "@solana/spl-token": "^0.4.6",
-    "@solana/spl-token-group":"^0.0.4",
-    "@solana/spl-token-metadata":"^0.1.4",
+    "@solana/spl-token-group": "^0.0.4",
+    "@solana/spl-token-metadata": "^0.1.4",
     "@solana/web3.js": "^1.91.7",
     "@types/node-fetch": "^2.6.11",
     "anchor-0.29.0": "npm:@coral-xyz/anchor@^0.29.0",
+    "bn.js": "^5.2.1",
     "dotenv": "^16.4.1",
     "ethers": "^5.7.2",
     "sha3": "^2.1.4",


### PR DESCRIPTION
Right now, it is not possible to use `@wormhole-foundation/example-liquidity-layer-solana` package outside this project:

```
unhandledRejection Error: Assertion failed
    at assert (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:6:21)
    at BN._initArray (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:145:5)
    at BN.init [as _init] (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:86:19)
    at new BN (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:39:12)
    at constructor (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/@solana/web3.js/src/publickey.ts:69:20)
    at translateAddress (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/@coral-xyz/anchor/src/program/common.ts:58:51)
    at Program (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/@coral-xyz/anchor/src/program/index.ts:273:33)
    at MatchingEngineProgram (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/solana/ts/src/matchingEngine/index.ts:222:24)
    at ContractRegistry.createMatchingEngineProgram (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/src/registry/ContractRegistry.ts:56:12)
    at ContractRegistry.getMatchingEngineProgram (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/src/registry/ContractRegistry.ts:65:41) Promise {
  <rejected> Error: Assertion failed
      at assert (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:6:21)
      at BN._initArray (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:145:5)
      at BN.init [as _init] (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:86:19)
      at new BN (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/bn.js/lib/bn.js:39:12)
      at constructor (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/@solana/web3.js/src/publickey.ts:69:20)
      at translateAddress (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/@coral-xyz/anchor/src/program/common.ts:58:51)
      at Program (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/node_modules/@coral-xyz/anchor/src/program/index.ts:273:33)
      at MatchingEngineProgram (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/lib/example-liquidity-layer/solana/ts/src/matchingEngine/index.ts:222:24)
      at ContractRegistry.createMatchingEngineProgram (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/src/registry/ContractRegistry.ts:56:12)
      at ContractRegistry.getMatchingEngineProgram (/Users/livthomas/Projects/rockawayx-labs/wormhole-solver/src/registry/ContractRegistry.ts:65:41)
}
```

It looks like this is caused by some assertion in `bn.js` library which probably fails because this dependecy is included twice (in two different versions):

```
node_modules/bn.js
  bn.js@"^5.1.2" from anchor-0.29.0@0.29.0
  node_modules/anchor-0.29.0
    anchor-0.29.0@"npm:@coral-xyz/anchor@^0.29.0" from @wormhole-foundation/example-liquidity-layer-solana@0.0.1
    solana
      @wormhole-foundation/example-liquidity-layer-solana@0.0.1
      node_modules/@wormhole-foundation/example-liquidity-layer-solana
        @wormhole-foundation/example-liquidity-layer-solana@"0.0.1" from @wormhole-foundation/example-liquidity-layer-solver@0.0.1
        solver
          @wormhole-foundation/example-liquidity-layer-solver@0.0.1
          node_modules/@wormhole-foundation/example-liquidity-layer-solver
            workspace solver from the root project
        workspace solana from the root project
  bn.js@"^5.2.0" from borsh@0.7.0
  node_modules/borsh
    borsh@"^0.7.0" from @solana/web3.js@1.91.7
    node_modules/@solana/web3.js
      @solana/web3.js@"^1.68.0" from anchor-0.29.0@0.29.0
      node_modules/anchor-0.29.0
        anchor-0.29.0@"npm:@coral-xyz/anchor@^0.29.0" from @wormhole-foundation/example-liquidity-layer-solana@0.0.1
        solana
          @wormhole-foundation/example-liquidity-layer-solana@0.0.1
          node_modules/@wormhole-foundation/example-liquidity-layer-solana
            @wormhole-foundation/example-liquidity-layer-solana@"0.0.1" from @wormhole-foundation/example-liquidity-layer-solver@0.0.1
            solver
              @wormhole-foundation/example-liquidity-layer-solver@0.0.1
              node_modules/@wormhole-foundation/example-liquidity-layer-solver
                workspace solver from the root project
            workspace solana from the root project
```

When I add it to `package.json`, it works without any problems.