### PR TITLE
solana: fix `LocalFastOrderFilled` type

### DIFF
--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -182,7 +182,6 @@ export type Enacted = {
 
 export type LocalFastOrderFilled = {
     seeds: FastFillSeeds;
-    preparedBy: PublicKey;
     info: FastFillInfo;
 };
 

--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -183,6 +183,7 @@ export type Enacted = {
 export type LocalFastOrderFilled = {
     seeds: FastFillSeeds;
     info: FastFillInfo;
+    auction: PublicKey | null;
 };
 
 export type FastFillSequenceReserved = {


### PR DESCRIPTION
This PR fixes incorrect type. Example `LocalFastOrderFilled`  order looks like this:

```
{
  "process": "sync",
  "data": {
    "seeds": {
      "sourceChain": 10003,
      "orderSender": [...],
      "sequence": "1281",
      "bump": 255
    },
    "info": {
      "preparedBy": "gyVfT39y3tWQnfXwxY6Hj7ZeLFN2K8Z6heWEJ4zxYRB",
      "amount": "7a1200",
      "redeemer": "D1LLYchgdMZ8M8j8XdvUzCYCjZXhTMXSAg6WS1SAi7oN",
      "timestamp": "6672d177"
    },
    "auction": "DJcvFfdymRXFyCm42JNsVmVPDw5fX666iBaNCeC2hqg2"
  }
} 
```