### PR TITLE
solana: emit -> emit_cpi

### DIFF
--- a/solana/programs/matching-engine/src/composite/mod.rs
+++ b/solana/programs/matching-engine/src/composite/mod.rs
@@ -97,7 +97,7 @@ pub struct CheckedCustodian<'info> {
         seeds = [Custodian::SEED_PREFIX],
         bump = Custodian::BUMP,
     )]
-    pub custodian: Account<'info, Custodian>,
+    pub custodian: Box<Account<'info, Custodian>>,
 }
 
 impl<'info> Deref for CheckedCustodian<'info> {
@@ -138,7 +138,7 @@ pub struct OwnerOnlyMut<'info> {
         seeds = [Custodian::SEED_PREFIX],
         bump = Custodian::BUMP,
     )]
-    pub custodian: Account<'info, Custodian>,
+    pub custodian: Box<Account<'info, Custodian>>,
 }
 
 #[derive(Accounts)]
@@ -171,7 +171,7 @@ pub struct AdminMut<'info> {
         seeds = [Custodian::SEED_PREFIX],
         bump = Custodian::BUMP,
     )]
-    pub custodian: Account<'info, Custodian>,
+    pub custodian: Box<Account<'info, Custodian>>,
 }
 
 #[derive(Accounts)]
@@ -195,7 +195,7 @@ pub struct LocalTokenRouter<'info> {
         associated_token::mint = common::USDC_MINT,
         associated_token::authority = token_router_emitter,
     )]
-    pub token_router_mint_recipient: Account<'info, token::TokenAccount>,
+    pub token_router_mint_recipient: Box<Account<'info, token::TokenAccount>>,
 }
 
 #[derive(Accounts)]
@@ -208,7 +208,7 @@ pub struct ExistingMutRouterEndpoint<'info> {
         ],
         bump = endpoint.bump,
     )]
-    pub endpoint: Account<'info, RouterEndpoint>,
+    pub endpoint: Box<Account<'info, RouterEndpoint>>,
 }
 
 impl<'info> Deref for ExistingMutRouterEndpoint<'info> {
@@ -644,7 +644,7 @@ pub struct ReserveFastFillSequence<'info> {
                 // This check makes sure that the auction account did not exist before this
                 // instruction was called.
                 require!(
-                    auction.vaa_hash == [0; 32],
+                    auction.vaa_hash == <[u8; 32]>::default(),
                     MatchingEngineError::AuctionExists,
                 );
 

--- a/solana/programs/matching-engine/src/events/auction_settled.rs
+++ b/solana/programs/matching-engine/src/events/auction_settled.rs
@@ -11,7 +11,7 @@ pub struct SettledTokenAccountInfo {
 #[derive(Debug)]
 pub struct AuctionSettled {
     /// The pubkey of the auction that was settled.
-    pub auction: Pubkey,
+    pub fast_vaa_hash: [u8; 32],
 
     /// If there was an active auction, this field will have the pubkey of the best offer token that
     /// was paid back and its balance after repayment.

--- a/solana/programs/matching-engine/src/events/auction_updated.rs
+++ b/solana/programs/matching-engine/src/events/auction_updated.rs
@@ -5,7 +5,7 @@ use anchor_lang::prelude::*;
 #[derive(Debug)]
 pub struct AuctionUpdated {
     pub config_id: u32,
-    pub auction: Pubkey,
+    pub fast_vaa_hash: [u8; 32],
     pub vaa: Option<Pubkey>,
     pub source_chain: u16,
     pub target_protocol: MessageProtocol,

--- a/solana/programs/matching-engine/src/events/fast_fill_redeemed.rs
+++ b/solana/programs/matching-engine/src/events/fast_fill_redeemed.rs
@@ -1,7 +1,9 @@
 use anchor_lang::prelude::*;
 
+use crate::state::FastFillSeeds;
+
 #[event]
 pub struct FastFillRedeemed {
     pub prepared_by: Pubkey,
-    pub fast_fill: Pubkey,
+    pub fast_fill: FastFillSeeds,
 }

--- a/solana/programs/matching-engine/src/events/fast_fill_sequence_reserved.rs
+++ b/solana/programs/matching-engine/src/events/fast_fill_sequence_reserved.rs
@@ -4,5 +4,5 @@ use anchor_lang::prelude::*;
 #[event]
 pub struct FastFillSequenceReserved {
     pub fast_vaa_hash: [u8; 32],
-    pub fast_fill_seeds: FastFillSeeds,
+    pub fast_fill: FastFillSeeds,
 }

--- a/solana/programs/matching-engine/src/events/order_executed.rs
+++ b/solana/programs/matching-engine/src/events/order_executed.rs
@@ -4,7 +4,7 @@ use anchor_lang::prelude::*;
 #[event]
 #[derive(Debug)]
 pub struct OrderExecuted {
-    pub auction: Pubkey,
+    pub fast_vaa_hash: [u8; 32],
     pub vaa: Pubkey,
     pub source_chain: u16,
     pub target_protocol: MessageProtocol,

--- a/solana/programs/matching-engine/src/processor/admin/init_event.rs
+++ b/solana/programs/matching-engine/src/processor/admin/init_event.rs
@@ -1,0 +1,26 @@
+use anchor_lang::prelude::*;
+
+use crate::composite::*;
+
+#[derive(Accounts)]
+pub struct InitEventSubscription<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    admin: OwnerOnly<'info>,
+
+    /// This account will be serialized with an event, so its discriminator will change with every
+    /// update.
+    ///
+    /// CHECK: Mutable, must have seeds \["event"\].
+    #[account(
+        init,
+        payer = payer,
+        space = 10_240,
+        seeds = [b"event"],
+        bump,
+    )]
+    event_subscription: UncheckedAccount<'info>,
+
+    system_program: Program<'info, System>,
+}

--- a/solana/programs/matching-engine/src/processor/admin/propose/auction_parameters.rs
+++ b/solana/programs/matching-engine/src/processor/admin/propose/auction_parameters.rs
@@ -6,6 +6,7 @@ use crate::{
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
+#[event_cpi]
 pub struct ProposeAuctionParameters<'info> {
     #[account(mut)]
     payer: Signer<'info>,
@@ -56,7 +57,7 @@ pub fn propose_auction_parameters(
     )?;
 
     // Emit event reflecting the proposal.
-    emit!(crate::events::Proposed { action });
+    emit_cpi!(crate::events::Proposed { action });
 
     // Done.
     Ok(())

--- a/solana/programs/matching-engine/src/processor/admin/update/auction_parameters.rs
+++ b/solana/programs/matching-engine/src/processor/admin/update/auction_parameters.rs
@@ -6,6 +6,7 @@ use crate::{
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
+#[event_cpi]
 pub struct UpdateAuctionParameters<'info> {
     #[account(mut)]
     payer: Signer<'info>,
@@ -70,7 +71,7 @@ pub fn update_auction_parameters(ctx: Context<UpdateAuctionParameters>) -> Resul
     let action = ctx.accounts.proposal.action;
 
     // Emit event to reflect enacting the proposal.
-    emit!(crate::events::Enacted { action });
+    emit_cpi!(crate::events::Enacted { action });
 
     match action {
         ProposalAction::UpdateAuctionParameters { id, parameters } => {

--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
@@ -214,7 +214,7 @@ fn handle_execute_fast_order<'info>(
                 execute_penalty: if penalized { penalty.into() } else { None },
             },
             OrderExecuted {
-                auction: auction.key(),
+                fast_vaa_hash: auction.vaa_hash,
                 vaa: fast_vaa.key(),
                 source_chain: auction_info.source_chain,
                 target_protocol: auction.target_protocol,

--- a/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
@@ -5,6 +5,7 @@ use common::TRANSFER_AUTHORITY_SEED_PREFIX;
 
 #[derive(Accounts)]
 #[instruction(offer_price: u64)]
+#[event_cpi]
 pub struct ImproveOffer<'info> {
     /// The auction participant needs to set approval to this PDA.
     ///
@@ -134,7 +135,7 @@ pub fn improve_offer(ctx: Context<ImproveOffer>, offer_price: u64) -> Result<()>
         let info = auction.info.as_ref().unwrap();
 
         // Emit event for auction participants to listen to.
-        emit!(crate::events::AuctionUpdated {
+        emit_cpi!(crate::utils::log_emit(crate::events::AuctionUpdated {
             config_id: info.config_id,
             auction: auction.key(),
             vaa: Default::default(),
@@ -148,7 +149,7 @@ pub fn improve_offer(ctx: Context<ImproveOffer>, offer_price: u64) -> Result<()>
             total_deposit: info.total_deposit(),
             max_offer_price_allowed: utils::auction::compute_min_allowed_offer(config, info)
                 .checked_sub(1),
-        });
+        }));
     }
 
     // Done.

--- a/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/improve.rs
@@ -137,7 +137,7 @@ pub fn improve_offer(ctx: Context<ImproveOffer>, offer_price: u64) -> Result<()>
         // Emit event for auction participants to listen to.
         emit_cpi!(crate::utils::log_emit(crate::events::AuctionUpdated {
             config_id: info.config_id,
-            auction: auction.key(),
+            fast_vaa_hash: auction.vaa_hash,
             vaa: Default::default(),
             source_chain: info.source_chain,
             target_protocol: auction.target_protocol,

--- a/solana/programs/matching-engine/src/processor/auction/offer/place_initial/cctp.rs
+++ b/solana/programs/matching-engine/src/processor/auction/offer/place_initial/cctp.rs
@@ -169,7 +169,7 @@ pub fn place_initial_offer_cctp(
     // Emit event for auction participants to listen to.
     emit_cpi!(crate::utils::log_emit(crate::events::AuctionUpdated {
         config_id: info.config_id,
-        auction: ctx.accounts.auction.key(),
+        fast_vaa_hash: ctx.accounts.auction.vaa_hash,
         vaa: ctx.accounts.fast_order_path.fast_vaa.key().into(),
         source_chain: info.source_chain,
         target_protocol: ctx.accounts.auction.target_protocol,

--- a/solana/programs/matching-engine/src/processor/auction/settle/complete.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/complete.rs
@@ -249,7 +249,7 @@ fn handle_settle_auction_complete(
     };
 
     emit_cpi!(crate::events::AuctionSettled {
-        auction: ctx.accounts.auction.key(),
+        fast_vaa_hash: ctx.accounts.auction.vaa_hash,
         best_offer_token: settled_best_offer_result,
         base_fee_token: settled_base_fee_result,
         with_execute: Default::default(),

--- a/solana/programs/matching-engine/src/processor/auction/settle/complete.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/complete.rs
@@ -8,6 +8,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{self, TokenAccount};
 
 #[derive(Accounts)]
+#[event_cpi]
 pub struct SettleAuctionComplete<'info> {
     /// CHECK: Must equal prepared_order_response.prepared_by, who paid the rent to post the
     /// finalized VAA.
@@ -247,7 +248,7 @@ fn handle_settle_auction_complete(
         None => None,
     };
 
-    emit!(crate::events::AuctionSettled {
+    emit_cpi!(crate::events::AuctionSettled {
         auction: ctx.accounts.auction.key(),
         best_offer_token: settled_best_offer_result,
         base_fee_token: settled_base_fee_result,

--- a/solana/programs/matching-engine/src/processor/auction/settle/none/local.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/none/local.rs
@@ -126,6 +126,7 @@ pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result
     let super::SettledNone {
         user_amount: amount,
         fill,
+        auction_settled_event,
     } = super::settle_none_and_prepare_fill(super::SettleNoneAndPrepareFill {
         prepared_order_response: &mut ctx.accounts.prepared.order_response,
         prepared_custody_token,
@@ -135,6 +136,9 @@ pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result
         token_program,
     })?;
 
+    // Emit an event indicating that the auction has been settled.
+    emit_cpi!(auction_settled_event);
+
     let fast_fill = FastFill::new(
         fill,
         ctx.accounts.reserved_sequence.fast_fill_seeds.sequence,
@@ -142,6 +146,8 @@ pub fn settle_auction_none_local(ctx: Context<SettleAuctionNoneLocal>) -> Result
         ctx.accounts.payer.key(),
         amount,
     );
+
+    // Emit the fast fill.
     emit_cpi!(crate::events::LocalFastOrderFilled {
         seeds: fast_fill.seeds,
         info: fast_fill.info,

--- a/solana/programs/matching-engine/src/processor/auction/settle/none/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/settle/none/mod.rs
@@ -84,7 +84,7 @@ fn settle_none_and_prepare_fill(accounts: SettleNoneAndPrepareFill<'_, '_>) -> R
     };
 
     let auction_settled_event = AuctionSettled {
-        auction: auction.key(),
+        fast_vaa_hash: auction.vaa_hash,
         best_offer_token: Default::default(),
         base_fee_token: crate::events::SettledTokenAccountInfo {
             key: fee_recipient_token.key(),

--- a/solana/programs/matching-engine/src/processor/fast_fill/complete.rs
+++ b/solana/programs/matching-engine/src/processor/fast_fill/complete.rs
@@ -9,6 +9,7 @@ use common::wormhole_cctp_solana::wormhole::SOLANA_CHAIN;
 
 /// Accounts required for [complete_fast_fill].
 #[derive(Accounts)]
+#[event_cpi]
 pub struct CompleteFastFill<'info> {
     /// Custodian, which may be used in the future.
     custodian: CheckedCustodian<'info>,
@@ -81,7 +82,7 @@ pub fn complete_fast_fill(ctx: Context<CompleteFastFill>) -> Result<()> {
     ctx.accounts.fast_fill.redeemed = true;
 
     // Emit event that the fast fill is redeemed. Listeners can close this account.
-    emit!(crate::events::FastFillRedeemed {
+    emit_cpi!(crate::events::FastFillRedeemed {
         prepared_by: ctx.accounts.fast_fill.info.prepared_by,
         fast_fill: ctx.accounts.fast_fill.key(),
     });

--- a/solana/programs/matching-engine/src/processor/fast_fill/complete.rs
+++ b/solana/programs/matching-engine/src/processor/fast_fill/complete.rs
@@ -31,7 +31,7 @@ pub struct CompleteFastFill<'info> {
         bump = fast_fill.seeds.bump,
         constraint = !fast_fill.redeemed @ MatchingEngineError::FastFillAlreadyRedeemed,
     )]
-    fast_fill: Account<'info, FastFill>,
+    fast_fill: Box<Account<'info, FastFill>>,
 
     /// Only the registered local Token Router program can call this instruction. It is allowed to
     /// invoke this instruction by using its emitter (i.e. its Custodian account) as a signer. We
@@ -43,7 +43,7 @@ pub struct CompleteFastFill<'info> {
         mut,
         token::mint = local_custody_token.mint,
     )]
-    token_router_custody_token: Account<'info, token::TokenAccount>,
+    token_router_custody_token: Box<Account<'info, token::TokenAccount>>,
 
     #[account(
         constraint = {
@@ -84,7 +84,7 @@ pub fn complete_fast_fill(ctx: Context<CompleteFastFill>) -> Result<()> {
     // Emit event that the fast fill is redeemed. Listeners can close this account.
     emit_cpi!(crate::events::FastFillRedeemed {
         prepared_by: ctx.accounts.fast_fill.info.prepared_by,
-        fast_fill: ctx.accounts.fast_fill.key(),
+        fast_fill: ctx.accounts.fast_fill.seeds,
     });
 
     // Finally transfer to local token router's token account.

--- a/solana/programs/matching-engine/src/processor/fast_fill/reserve_sequence/active_auction.rs
+++ b/solana/programs/matching-engine/src/processor/fast_fill/reserve_sequence/active_auction.rs
@@ -2,6 +2,7 @@ use crate::{composite::*, error::MatchingEngineError, state::AuctionConfig};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
+#[event_cpi]
 pub struct ReserveFastFillSequenceActiveAuction<'info> {
     reserve_sequence: ReserveFastFillSequence<'info>,
 
@@ -34,10 +35,15 @@ pub fn reserve_fast_fill_sequence_active_auction(
     let beneficiary = ctx.accounts.reserve_sequence.payer.key();
     let fast_vaa_hash = ctx.accounts.reserve_sequence.auction.vaa_hash;
 
-    super::set_reserved_sequence_data(
+    let sequence_reserved_event = super::set_reserved_sequence_data(
         &mut ctx.accounts.reserve_sequence,
         &ctx.bumps.reserve_sequence,
         fast_vaa_hash,
         beneficiary,
-    )
+    )?;
+
+    // Emit an event indicating that the fast fill sequence has been reserved.
+    emit_cpi!(sequence_reserved_event);
+
+    Ok(())
 }

--- a/solana/programs/matching-engine/src/processor/fast_fill/reserve_sequence/mod.rs
+++ b/solana/programs/matching-engine/src/processor/fast_fill/reserve_sequence/mod.rs
@@ -7,6 +7,7 @@ pub use no_auction::*;
 use crate::{
     composite::*,
     error::MatchingEngineError,
+    events::FastFillSequenceReserved,
     state::{
         FastFillSeeds, FastFillSequencer, FastFillSequencerSeeds, ReservedFastFillSequence,
         ReservedFastFillSequenceSeeds,
@@ -20,7 +21,7 @@ fn set_reserved_sequence_data(
     bumps: &ReserveFastFillSequenceBumps,
     fast_vaa_hash: [u8; 32],
     beneficiary: Pubkey,
-) -> Result<()> {
+) -> Result<FastFillSequenceReserved> {
     let sequencer = &mut reserve_sequence.sequencer;
 
     // If the fast fill sequencer was just created, we need to set it with data.
@@ -76,13 +77,10 @@ fn set_reserved_sequence_data(
         .checked_add(1)
         .ok_or_else(|| MatchingEngineError::U64Overflow)?;
 
-    // Emit an event to help auction participants track the fast fill sequence so they can more
+    // Prepare an event to help auction participants track the fast fill sequence so they can more
     // easily execute local orders.
-    emit!(crate::events::FastFillSequenceReserved {
+    Ok(FastFillSequenceReserved {
         fast_vaa_hash,
         fast_fill_seeds,
-    });
-
-    // Done.
-    Ok(())
+    })
 }

--- a/solana/programs/matching-engine/src/processor/fast_fill/reserve_sequence/mod.rs
+++ b/solana/programs/matching-engine/src/processor/fast_fill/reserve_sequence/mod.rs
@@ -81,6 +81,6 @@ fn set_reserved_sequence_data(
     // easily execute local orders.
     Ok(FastFillSequenceReserved {
         fast_vaa_hash,
-        fast_fill_seeds,
+        fast_fill: fast_fill_seeds,
     })
 }

--- a/solana/programs/matching-engine/src/utils/mod.rs
+++ b/solana/programs/matching-engine/src/utils/mod.rs
@@ -57,3 +57,13 @@ pub fn checked_deserialize_token_account(
             .map(Box::new)
     }
 }
+
+/// This method is just used out of convenience to return the same event that was emitted so
+/// something like `emit_cpi!` can be used on the same event.
+pub fn log_emit<E>(event: E) -> E
+where
+    E: anchor_lang::Event,
+{
+    emit!(event);
+    event
+}

--- a/solana/programs/token-router/src/processor/redeem_fill/fast.rs
+++ b/solana/programs/token-router/src/processor/redeem_fill/fast.rs
@@ -73,6 +73,9 @@ pub struct RedeemFastFill<'info> {
     #[account(mut)]
     matching_engine_local_custody_token: UncheckedAccount<'info>,
 
+    /// CHECK: Seeds must be \["__event_authority"] (Matching Engine program).
+    matching_engine_event_authority: UncheckedAccount<'info>,
+
     matching_engine_program: Program<'info, matching_engine::program::MatchingEngine>,
     token_program: Program<'info, token::Token>,
     system_program: Program<'info, System>,
@@ -112,6 +115,11 @@ fn handle_redeem_fast_fill(ctx: Context<RedeemFastFill>) -> Result<()> {
                 .matching_engine_local_custody_token
                 .to_account_info(),
             token_program: ctx.accounts.token_program.to_account_info(),
+            event_authority: ctx
+                .accounts
+                .matching_engine_event_authority
+                .to_account_info(),
+            program: ctx.accounts.matching_engine_program.to_account_info(),
         },
         &[Custodian::SIGNER_SEEDS],
     ))?;

--- a/solana/ts/src/idl/json/matching_engine.json
+++ b/solana/ts/src/idl/json/matching_engine.json
@@ -3535,11 +3535,16 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "auction",
+            "name": "fast_vaa_hash",
             "docs": [
               "The pubkey of the auction that was settled."
             ],
-            "type": "pubkey"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "best_offer_token",
@@ -3640,8 +3645,13 @@
             "type": "u32"
           },
           {
-            "name": "auction",
-            "type": "pubkey"
+            "name": "fast_vaa_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "vaa",
@@ -3911,7 +3921,11 @@
           },
           {
             "name": "fast_fill",
-            "type": "pubkey"
+            "type": {
+              "defined": {
+                "name": "FastFillSeeds"
+              }
+            }
           }
         ]
       }
@@ -3973,7 +3987,7 @@
             }
           },
           {
-            "name": "fast_fill_seeds",
+            "name": "fast_fill",
             "type": {
               "defined": {
                 "name": "FastFillSeeds"
@@ -4115,8 +4129,13 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "auction",
-            "type": "pubkey"
+            "name": "fast_vaa_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "vaa",

--- a/solana/ts/src/idl/json/matching_engine.json
+++ b/solana/ts/src/idl/json/matching_engine.json
@@ -437,6 +437,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -802,6 +808,12 @@
               ]
             }
           ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1009,6 +1021,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1273,6 +1291,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1528,6 +1552,12 @@
         },
         {
           "name": "epoch_schedule"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1649,6 +1679,12 @@
         },
         {
           "name": "auction_config"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1772,6 +1808,12 @@
             "closed. This instruction will not allow this account to be provided if there is an existing",
             "auction, which would enforce the order be executed when it is time to complete the auction."
           ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1883,6 +1925,12 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -2062,6 +2110,12 @@
               ]
             }
           ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -2287,6 +2341,12 @@
         },
         {
           "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []

--- a/solana/ts/src/idl/json/token_router.json
+++ b/solana/ts/src/idl/json/token_router.json
@@ -846,6 +846,9 @@
           "writable": true
         },
         {
+          "name": "matching_engine_event_authority"
+        },
+        {
           "name": "matching_engine_program"
         },
         {

--- a/solana/ts/src/idl/ts/matching_engine.ts
+++ b/solana/ts/src/idl/ts/matching_engine.ts
@@ -3541,11 +3541,16 @@ export type MatchingEngine = {
         "kind": "struct",
         "fields": [
           {
-            "name": "auction",
+            "name": "fastVaaHash",
             "docs": [
               "The pubkey of the auction that was settled."
             ],
-            "type": "pubkey"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "bestOfferToken",
@@ -3646,8 +3651,13 @@ export type MatchingEngine = {
             "type": "u32"
           },
           {
-            "name": "auction",
-            "type": "pubkey"
+            "name": "fastVaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "vaa",
@@ -3917,7 +3927,11 @@ export type MatchingEngine = {
           },
           {
             "name": "fastFill",
-            "type": "pubkey"
+            "type": {
+              "defined": {
+                "name": "fastFillSeeds"
+              }
+            }
           }
         ]
       }
@@ -3979,7 +3993,7 @@ export type MatchingEngine = {
             }
           },
           {
-            "name": "fastFillSeeds",
+            "name": "fastFill",
             "type": {
               "defined": {
                 "name": "fastFillSeeds"
@@ -4121,8 +4135,13 @@ export type MatchingEngine = {
         "kind": "struct",
         "fields": [
           {
-            "name": "auction",
-            "type": "pubkey"
+            "name": "fastVaaHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "vaa",

--- a/solana/ts/src/idl/ts/matching_engine.ts
+++ b/solana/ts/src/idl/ts/matching_engine.ts
@@ -443,6 +443,12 @@ export type MatchingEngine = {
         },
         {
           "name": "tokenProgram"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -808,6 +814,12 @@ export type MatchingEngine = {
               ]
             }
           ]
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1015,6 +1027,12 @@ export type MatchingEngine = {
         },
         {
           "name": "tokenProgram"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1279,6 +1297,12 @@ export type MatchingEngine = {
         },
         {
           "name": "tokenProgram"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1534,6 +1558,12 @@ export type MatchingEngine = {
         },
         {
           "name": "epochSchedule"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -1655,6 +1685,12 @@ export type MatchingEngine = {
         },
         {
           "name": "auctionConfig"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1778,6 +1814,12 @@ export type MatchingEngine = {
             "closed. This instruction will not allow this account to be provided if there is an existing",
             "auction, which would enforce the order be executed when it is time to complete the auction."
           ]
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -1889,6 +1931,12 @@ export type MatchingEngine = {
         },
         {
           "name": "tokenProgram"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -2068,6 +2116,12 @@ export type MatchingEngine = {
               ]
             }
           ]
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
@@ -2293,6 +2347,12 @@ export type MatchingEngine = {
         },
         {
           "name": "systemProgram"
+        },
+        {
+          "name": "eventAuthority"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []

--- a/solana/ts/src/idl/ts/token_router.ts
+++ b/solana/ts/src/idl/ts/token_router.ts
@@ -852,6 +852,9 @@ export type TokenRouter = {
           "writable": true
         },
         {
+          "name": "matchingEngineEventAuthority"
+        },
+        {
           "name": "matchingEngineProgram"
         },
         {

--- a/solana/ts/src/matchingEngine/index.ts
+++ b/solana/ts/src/matchingEngine/index.ts
@@ -147,7 +147,7 @@ export type SettledTokenAccountInfo = {
 };
 
 export type AuctionSettled = {
-    auction: PublicKey;
+    fastVaaHash: Array<number>;
     bestOfferToken: SettledTokenAccountInfo | null;
     baseFeeToken: SettledTokenAccountInfo | null;
     withExecute: MessageProtocol | null;
@@ -155,7 +155,7 @@ export type AuctionSettled = {
 
 export type AuctionUpdated = {
     configId: number;
-    auction: PublicKey;
+    fastVaaHash: Array<number>;
     vaa: PublicKey | null;
     sourceChain: number;
     targetProtocol: MessageProtocol;
@@ -169,7 +169,7 @@ export type AuctionUpdated = {
 };
 
 export type OrderExecuted = {
-    auction: PublicKey;
+    fastVaaHash: Array<number>;
     vaa: PublicKey;
     targetProtocol: MessageProtocol;
 };
@@ -190,12 +190,12 @@ export type LocalFastOrderFilled = {
 
 export type FastFillSequenceReserved = {
     fastVaaHash: Array<number>;
-    fastFillSeeds: FastFillSeeds;
+    fastFill: FastFillSeeds;
 };
 
 export type FastFillRedeemed = {
     preparedBy: PublicKey;
-    fastFill: PublicKey;
+    fastFill: FastFillSeeds;
 };
 
 export type MatchingEngineEvent = {

--- a/solana/ts/src/tokenRouter/index.ts
+++ b/solana/ts/src/tokenRouter/index.ts
@@ -103,6 +103,7 @@ export type RedeemFastFillAccounts = {
     matchingEngineFromEndpoint: PublicKey;
     matchingEngineToEndpoint: PublicKey;
     matchingEngineLocalCustodyToken: PublicKey;
+    matchingEngineEventAuthority: PublicKey;
     matchingEngineProgram: PublicKey;
 };
 
@@ -729,6 +730,7 @@ export class TokenRouterProgram {
             fromRouterEndpoint: matchingEngineFromEndpoint,
             toRouterEndpoint: matchingEngineToEndpoint,
             localCustodyToken: matchingEngineLocalCustodyToken,
+            eventAuthority: matchingEngineEventAuthority,
             matchingEngineProgram,
         } = await this.matchingEngineProgram().redeemFastFillAccounts(fastFill);
 
@@ -740,6 +742,7 @@ export class TokenRouterProgram {
             matchingEngineFromEndpoint,
             matchingEngineToEndpoint,
             matchingEngineLocalCustodyToken,
+            matchingEngineEventAuthority,
             matchingEngineProgram,
         };
     }
@@ -754,6 +757,7 @@ export class TokenRouterProgram {
             matchingEngineFromEndpoint,
             matchingEngineToEndpoint,
             matchingEngineLocalCustodyToken,
+            matchingEngineEventAuthority,
             matchingEngineProgram,
         } = await this.redeemFastFillAccounts(fastFill);
 
@@ -770,6 +774,7 @@ export class TokenRouterProgram {
                 matchingEngineFromEndpoint,
                 matchingEngineToEndpoint,
                 matchingEngineLocalCustodyToken,
+                matchingEngineEventAuthority,
                 matchingEngineProgram,
                 tokenProgram: splToken.TOKEN_PROGRAM_ID,
                 systemProgram: SystemProgram.programId,

--- a/solana/ts/src/utils.ts
+++ b/solana/ts/src/utils.ts
@@ -10,3 +10,64 @@ export function programDataAddress(programId: PublicKey) {
         BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
     )[0];
 }
+
+export class ArrayQueue<T> {
+    private _data: Array<T | null>;
+    private _size: number = 0;
+    private _index: number = 0;
+
+    constructor(capacity?: number) {
+        this._data = new Array(capacity ?? 256).fill(null);
+    }
+
+    head(): T {
+        if (this.isEmpty()) {
+            throw new Error("queue is empty");
+        }
+
+        return this._data[this._index]!;
+    }
+
+    enqueue(value: T): void {
+        const data = this._data;
+        const size = this._size;
+        const index = this._index;
+
+        if (size + 1 > data.length) {
+            this.resize();
+        }
+
+        data[(index + size) % data.length] = value;
+        ++this._size;
+    }
+
+    dequeue(): void {
+        const data = this._data;
+        const index = this._index;
+
+        this._index = (index + 1) % data.length;
+        --this._size;
+    }
+
+    resize(): void {
+        const data = this._data;
+        const size = this._size;
+        const index = this._index;
+
+        const newData = new Array(size * 2);
+        for (let i = 0; i < size; ++i) {
+            newData[i] = data[(index + i) % data.length];
+        }
+
+        this._data = newData;
+        this._index = 0;
+    }
+
+    isEmpty(): boolean {
+        return this._size == 0;
+    }
+
+    length(): number {
+        return this._size;
+    }
+}


### PR DESCRIPTION
Instead of using `emit!` by itself, we use `emit_cpi!` for all events. Only the `AuctionUpdated` event (emitted during the auction offer process) is written to the program logs in addition to event CPI.

This PR also adds an event listener in the Matching Engine SDK (`onEventCpi`) for the events that no longer log anything in program logs.

**This is a breaking change.** This PR modifies some event schemas to give more useful information. The Matching Engine SDK takes into account these schema changes. The following event schemas changed:

```rs
pub struct AuctionSettled {
    pub fast_vaa_hash: [u8; 32], // used to be `auction: Pubkey`
}

pub struct AuctionUpdated {
    pub config_id: u32,
    pub fast_vaa_hash: [u8; 32], // used to be `auction: Pubkey`
    ..
}

pub struct FastFillRedeemed {
    pub prepared_by: Pubkey,
    pub fast_fill: FastFillSeeds, // used to be `fast_fill: Pubkey`
}

pub struct OrderExecuted {
    pub fast_vaa_hash: [u8; 32], // used to be `auction: Pubkey`
    ..
}
```