### PR TITLE
evm: npm i ethers-v5 --save-prod

### DIFF
--- a/evm/package.json
+++ b/evm/package.json
@@ -43,7 +43,7 @@
     "chai": "^4.3.7",
     "dotenv": "^16.3.1",
     "envfile": "^7.1.0",
-    "ethers": "^5.7.2",
+    "ethers-v5": "npm:ethers@^5.7.2",
     "mocha": "^10.0.0",
     "prettier": "^2.8.7",
     "prettier-plugin-solidity": "^1.1.3",

--- a/evm/ts/tests/00__environment.ts
+++ b/evm/ts/tests/00__environment.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { execSync } from "child_process";
-import { ethers } from "ethers";
+import { ethers } from "ethers-v5";
 import {
     ICircleBridge__factory,
     IMessageTransmitter__factory,

--- a/evm/ts/tests/01__registration.ts
+++ b/evm/ts/tests/01__registration.ts
@@ -1,6 +1,6 @@
 import "@wormhole-foundation/sdk-evm/address";
 
-import { ethers } from "ethers";
+import { ethers } from "ethers-v5";
 import { ITokenRouter__factory, IMatchingEngine__factory } from "../src/types";
 import {
     LOCALHOSTS,

--- a/evm/ts/tests/02__configuration.ts
+++ b/evm/ts/tests/02__configuration.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers } from "ethers-v5";
 import { ITokenRouter__factory, IMatchingEngine__factory } from "../src/types";
 import {
     LOCALHOSTS,

--- a/evm/ts/tests/03__marketOrder.ts
+++ b/evm/ts/tests/03__marketOrder.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { ethers } from "ethers";
+import { ethers } from "ethers-v5";
 import { EvmTokenRouter, errorDecoder, OrderResponse } from "../src";
 import { IERC20__factory } from "../src/types";
 import {

--- a/evm/ts/tests/04__fastMarketOrder.ts
+++ b/evm/ts/tests/04__fastMarketOrder.ts
@@ -1,7 +1,7 @@
 import "@wormhole-foundation/sdk-evm/address";
 
 import { expect } from "chai";
-import { ethers } from "ethers";
+import { ethers } from "ethers-v5";
 import {
     EvmTokenRouter,
     EvmMatchingEngine,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "chai": "^4.3.7",
         "dotenv": "^16.3.1",
         "envfile": "^7.1.0",
-        "ethers": "^5.7.2",
+        "ethers-v5": "npm:ethers@^5.7.2",
         "mocha": "^10.0.0",
         "prettier": "^2.8.7",
         "prettier-plugin-solidity": "^1.1.3",
@@ -2367,6 +2367,56 @@
       }
     },
     "node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
+    "node_modules/ethers-v5": {
+      "name": "ethers",
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
       "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",


### PR DESCRIPTION
- Make ethers-v5 explicit so integrators know which ethers is being used when looking at the source

Adding an issue to upgrade ethers V5 to V6 in case the npm install vulnerability warnings scare integrators too much.