### PR TITLE
solana: fix redeem fast fill stack access violation

### DIFF
--- a/solana/programs/token-router/src/composite/mod.rs
+++ b/solana/programs/token-router/src/composite/mod.rs
@@ -87,7 +87,7 @@ pub struct CheckedCustodian<'info> {
         seeds = [Custodian::SEED_PREFIX],
         bump = Custodian::BUMP,
     )]
-    pub custodian: Account<'info, Custodian>,
+    pub custodian: Box<Account<'info, Custodian>>,
 }
 
 impl<'info> Deref for CheckedCustodian<'info> {
@@ -128,7 +128,7 @@ pub struct OwnerOnlyMut<'info> {
         seeds = [Custodian::SEED_PREFIX],
         bump = Custodian::BUMP,
     )]
-    pub custodian: Account<'info, Custodian>,
+    pub custodian: Box<Account<'info, Custodian>>,
 }
 
 #[derive(Accounts)]
@@ -161,7 +161,7 @@ pub struct AdminMut<'info> {
         seeds = [Custodian::SEED_PREFIX],
         bump = Custodian::BUMP,
     )]
-    pub custodian: Account<'info, Custodian>,
+    pub custodian: Box<Account<'info, Custodian>>,
 }
 
 /// Registered router endpoint representing a foreign Token Router. This account may have a CCTP

--- a/solana/programs/token-router/src/processor/redeem_fill/fast.rs
+++ b/solana/programs/token-router/src/processor/redeem_fill/fast.rs
@@ -25,7 +25,7 @@ pub struct RedeemFastFill<'info> {
         bump = fast_fill.seeds.bump,
         seeds::program = matching_engine_program,
     )]
-    fast_fill: Account<'info, FastFill>,
+    fast_fill: Box<Account<'info, FastFill>>,
 
     #[account(
         init_if_needed,
@@ -37,7 +37,7 @@ pub struct RedeemFastFill<'info> {
         ],
         bump,
     )]
-    prepared_fill: Account<'info, PreparedFill>,
+    prepared_fill: Box<Account<'info, PreparedFill>>,
 
     /// Mint recipient token account, which is encoded as the mint recipient in the CCTP message.
     /// The CCTP Token Messenger Minter program will transfer the amount encoded in the CCTP message

--- a/solana/sh/run_test_validator.sh
+++ b/solana/sh/run_test_validator.sh
@@ -99,6 +99,8 @@ solana-test-validator \
     8899 \
     --ticks-per-slot \
     $1 \
+    --deactivate-feature \
+    EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33 \
     --url \
     https://api.devnet.solana.com > /dev/null 2>&1 &
 


### PR DESCRIPTION
Direct data mapping being enabled avoided this stack access violation from cropping up in the local validator test. In order to safely test any instruction's potential stack access violations, disable this feature: https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/feature_set.rs#L616. 

Fix for token router: moar boxing