### PR TITLE
use current version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wormhole-foundation/example-liquidity-layer",
-  "version": "0.0.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wormhole-foundation/example-liquidity-layer",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "universal/ts",
@@ -20,10 +20,10 @@
     },
     "evm": {
       "name": "@wormhole-foundation/example-liquidity-layer-evm",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/example-liquidity-layer-definitions": "0.0.1",
+        "@wormhole-foundation/example-liquidity-layer-definitions": "0.4.0",
         "@wormhole-foundation/sdk-base": "^1.4.4",
         "@wormhole-foundation/sdk-definitions": "^1.4.4",
         "@wormhole-foundation/sdk-evm": "^1.4.4",
@@ -4209,7 +4209,7 @@
     },
     "solana": {
       "name": "@wormhole-foundation/example-liquidity-layer-solana",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "dependencies": {
         "@certusone/wormhole-spydk": "^0.0.1",
         "@coral-xyz/anchor": "^0.30.1",
@@ -4218,7 +4218,7 @@
         "@solana/spl-token-metadata": "^0.1.5",
         "@solana/web3.js": "^1.95.3",
         "@types/node-fetch": "^2.6.11",
-        "@wormhole-foundation/example-liquidity-layer-definitions": "0.0.1",
+        "@wormhole-foundation/example-liquidity-layer-definitions": "0.4.0",
         "@wormhole-foundation/sdk-base": "^1.4.4",
         "@wormhole-foundation/sdk-definitions": "^1.4.4",
         "@wormhole-foundation/sdk-evm": "^1.4.4",
@@ -4540,12 +4540,12 @@
     },
     "solver": {
       "name": "@wormhole-foundation/example-liquidity-layer-solver",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/spl-token": "^0.4.6",
-        "@wormhole-foundation/example-liquidity-layer-evm": "0.0.1",
-        "@wormhole-foundation/example-liquidity-layer-solana": "0.0.1",
+        "@wormhole-foundation/example-liquidity-layer-evm": "0.4.0",
+        "@wormhole-foundation/example-liquidity-layer-solana": "0.4.0",
         "@wormhole-foundation/sdk-base": "^1.4.4",
         "@wormhole-foundation/sdk-definitions": "^1.4.4",
         "@wormhole-foundation/sdk-solana": "^1.4.4"
@@ -4571,7 +4571,7 @@
     },
     "universal/ts": {
       "name": "@wormhole-foundation/example-liquidity-layer-definitions",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "^1.4.4",


### PR DESCRIPTION
We use this repository as a git submodule in our solver and after the latest version update, we get this diff every time we build it.